### PR TITLE
Add dotenv support and update dev proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist-ssr
 __pycache__
 *.pyc
 .venv
+
+# Environment variables
+.env

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,11 +5,14 @@ import time
 from contextlib import asynccontextmanager
 
 import httpx
+from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
+
+load_dotenv()
 
 FREE_GAMES_NOTIFIER_URL = os.getenv(
     "FREE_GAMES_NOTIFIER_URL", "http://free-games-notifier:8000"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.12
 httpx==0.28.1
 pydantic==2.12.5
+python-dotenv==1.0.1
 uvicorn==0.34.0

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/services': 'http://localhost:8000',
+      '/services': 'http://localhost:8001',
     },
   },
 })


### PR DESCRIPTION
Load environment variables from a .env file in the backend by adding python-dotenv and calling load_dotenv() in main.py. Add .env to .gitignore to avoid committing secrets. Also update Vite dev server proxy to forward /services to http://localhost:8001 (was 8000) to match the local backend setup.