### PR TITLE
Add "Remember me" toggle and safe storage helpers for API key persistence

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import ServiceCard from "./components/ServiceCard"
 import ActionPanel from "./components/ActionPanel"
 import Login from "./components/Login"
 import { getIcon } from "./utils/icons"
+import { safeLocalStorage, safeSessionStorage } from "./utils/storage"
 
 const REFRESH_INTERVAL_MS = 30_000
 
@@ -12,18 +13,25 @@ function App() {
   const [error, setError] = useState(null)
   const [lastUpdated, setLastUpdated] = useState(null)
   const [selectedService, setSelectedService] = useState(null)
-  const [apiKey, setApiKey] = useState(() => localStorage.getItem("apiKey") || "")
+  const [apiKey, setApiKey] = useState(
+    () => safeLocalStorage.getItem("apiKey") || safeSessionStorage.getItem("apiKey") || ""
+  )
   const [authError, setAuthError] = useState(false)
 
-  const handleLogin = (key) => {
+  const handleLogin = (key, rememberMe) => {
     setLoading(true)
     setApiKey(key)
-    localStorage.setItem("apiKey", key)
+    if (rememberMe) {
+      safeLocalStorage.setItem("apiKey", key)
+    } else {
+      safeSessionStorage.setItem("apiKey", key)
+    }
   }
 
   const handleLogout = () => {
     setApiKey("")
-    localStorage.removeItem("apiKey")
+    safeLocalStorage.removeItem("apiKey")
+    safeSessionStorage.removeItem("apiKey")
     setSelectedService(null)
     setServices([])
     setError(null)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,18 +12,18 @@ function App() {
   const [error, setError] = useState(null)
   const [lastUpdated, setLastUpdated] = useState(null)
   const [selectedService, setSelectedService] = useState(null)
-  const [apiKey, setApiKey] = useState(() => sessionStorage.getItem("apiKey") || "")
+  const [apiKey, setApiKey] = useState(() => localStorage.getItem("apiKey") || "")
   const [authError, setAuthError] = useState(false)
 
   const handleLogin = (key) => {
     setLoading(true)
     setApiKey(key)
-    sessionStorage.setItem("apiKey", key)
+    localStorage.setItem("apiKey", key)
   }
 
   const handleLogout = () => {
     setApiKey("")
-    sessionStorage.removeItem("apiKey")
+    localStorage.removeItem("apiKey")
     setSelectedService(null)
     setServices([])
     setError(null)

--- a/src/components/Login.css
+++ b/src/components/Login.css
@@ -64,6 +64,21 @@
   opacity: 0.85;
 }
 
+.remember-me {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: rgba(250, 250, 255, 0.5);
+  font-family: monospace;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.remember-me input[type="checkbox"] {
+  accent-color: var(--blueishWhite);
+  cursor: pointer;
+}
+
 .login-error {
   color: var(--red);
   font-family: monospace;

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -3,10 +3,11 @@ import "./Login.css"
 
 function Login({ onLogin, error }) {
   const [key, setKey] = useState("")
+  const [rememberMe, setRememberMe] = useState(false)
 
   const handleSubmit = (e) => {
     e.preventDefault()
-    if (key.trim()) onLogin(key.trim())
+    if (key.trim()) onLogin(key.trim(), rememberMe)
   }
 
   return (
@@ -20,6 +21,14 @@ function Login({ onLogin, error }) {
           onChange={(e) => setKey(e.target.value)}
           autoFocus
         />
+        <label className="remember-me">
+          <input
+            type="checkbox"
+            checked={rememberMe}
+            onChange={(e) => setRememberMe(e.target.checked)}
+          />
+          Remember me
+        </label>
         <button type="submit">Enter</button>
         {error && <p className="login-error">Invalid API Key</p>}
       </form>

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -3,7 +3,8 @@ const memoryStore = {}
 function safeGet(storage, key) {
   try {
     return storage.getItem(key)
-  } catch {
+  } catch (err) {
+    console.error("Storage read failed, falling back to memory:", err)
     return memoryStore[key] ?? null
   }
 }
@@ -11,7 +12,8 @@ function safeGet(storage, key) {
 function safeSet(storage, key, value) {
   try {
     storage.setItem(key, value)
-  } catch {
+  } catch (err) {
+    console.error("Storage write failed, falling back to memory:", err)
     memoryStore[key] = value
   }
 }
@@ -19,7 +21,8 @@ function safeSet(storage, key, value) {
 function safeRemove(storage, key) {
   try {
     storage.removeItem(key)
-  } catch {
+  } catch (err) {
+    console.error("Storage remove failed, falling back to memory:", err)
     delete memoryStore[key]
   }
 }

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,37 @@
+const memoryStore = {}
+
+function safeGet(storage, key) {
+  try {
+    return storage.getItem(key)
+  } catch {
+    return memoryStore[key] ?? null
+  }
+}
+
+function safeSet(storage, key, value) {
+  try {
+    storage.setItem(key, value)
+  } catch {
+    memoryStore[key] = value
+  }
+}
+
+function safeRemove(storage, key) {
+  try {
+    storage.removeItem(key)
+  } catch {
+    delete memoryStore[key]
+  }
+}
+
+export const safeLocalStorage = {
+  getItem: (key) => safeGet(localStorage, key),
+  setItem: (key, value) => safeSet(localStorage, key, value),
+  removeItem: (key) => safeRemove(localStorage, key),
+}
+
+export const safeSessionStorage = {
+  getItem: (key) => safeGet(sessionStorage, key),
+  setItem: (key, value) => safeSet(sessionStorage, key, value),
+  removeItem: (key) => safeRemove(sessionStorage, key),
+}


### PR DESCRIPTION
Storing the API key unconditionally in `localStorage` exposes it to XSS for the lifetime of the browser profile, and direct storage access can throw in restricted environments (Safari private mode, quota exceeded), crashing the app.

## Changes

- **`src/utils/storage.js`** — new safe storage wrappers for `localStorage`/`sessionStorage`; each operation is guarded with try/catch, logging the error and falling back to an in-memory store on failure
- **`src/components/Login.jsx`** — adds an opt-in "Remember me" checkbox (default: unchecked); passes `rememberMe` flag to `onLogin`
- **`src/App.jsx`** — defaults to `sessionStorage` (tab-scoped); uses `localStorage` only when "Remember me" is checked; logout clears both; init checks `localStorage` first, then `sessionStorage`

```js
// src/utils/storage.js
export const safeLocalStorage = {
  getItem:    (key)        => safeGet(localStorage, key),
  setItem:    (key, value) => safeSet(localStorage, key, value),
  removeItem: (key)        => safeRemove(localStorage, key),
}

// src/App.jsx — login handler
const handleLogin = (key, rememberMe) => {
  setApiKey(key)
  if (rememberMe) safeLocalStorage.setItem("apiKey", key)
  else            safeSessionStorage.setItem("apiKey", key)
}
```