### PR TITLE
fix: action timeout + background HTTP monitoring

### DIFF
--- a/backend/config_service.py
+++ b/backend/config_service.py
@@ -3,6 +3,7 @@ import re
 
 from fastapi import APIRouter
 from models import Action, ActionResult, Service
+from monitoring import get_status
 from upstream import call_upstream
 from yaml_models import YamlService
 
@@ -31,16 +32,16 @@ def yaml_to_card(svc: YamlService) -> Service:
                 ))
     return Service(
         name=svc.name,
-        status="unknown",
+        status=get_status(svc.name),
         icon=svc.icon or "server",
         url=svc.url,
         actions=actions or None,
     )
 
 
-def _make_handler(url: str, method: str, label: str, headers: dict | None, body: dict | None):
+def _make_handler(url: str, method: str, label: str, headers: dict | None, body: dict | None, timeout: float):
     def handler() -> ActionResult:
-        return call_upstream(url, method=method, label=label, headers=headers, body=body)
+        return call_upstream(url, method=method, label=label, headers=headers, body=body, timeout=timeout)
     return handler
 
 
@@ -62,7 +63,7 @@ def build_config_router(services: list[YamlService]) -> APIRouter:
             upstream_url = svc.action_url.rstrip("/") + action.endpoint
             path = f"/services/{slug}/actions/{_slug(action.label)}"
             headers = dict(svc.action_headers) if svc.action_headers else None
-            handler = _make_handler(upstream_url, action.method, action.label, headers, action.body)
+            handler = _make_handler(upstream_url, action.method, action.label, headers, action.body, svc.action_timeout)
             router.add_api_route(path, handler, methods=[action.method.upper()], response_model=ActionResult)
-            logger.info("Registered %s %s -> %s", action.method.upper(), path, upstream_url)
+            logger.info("Registered %s %s -> %s (timeout=%ss)", action.method.upper(), path, upstream_url, svc.action_timeout)
     return router

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,10 +7,13 @@ from fastapi import FastAPI, HTTPException, Security, status
 from fastapi.security import APIKeyHeader
 from fastapi.middleware.cors import CORSMiddleware
 
+import asyncio
+
 import http_client
 import config_loader
 from config_service import build_config_router, yaml_to_card
 from models import Service
+from monitoring import run_monitoring_loop
 
 load_dotenv()
 
@@ -38,8 +41,15 @@ def verify_api_key(api_key: str = Security(api_key_header)):
 async def lifespan(app: FastAPI):
     config_loader.load_config()
     http_client.init()
-    app.include_router(build_config_router(config_loader.get_services()))
+    services = config_loader.get_services()
+    app.include_router(build_config_router(services))
+    monitor_task = asyncio.create_task(run_monitoring_loop(services))
     yield
+    monitor_task.cancel()
+    try:
+        await monitor_task
+    except asyncio.CancelledError:
+        pass
     http_client.close()
 
 

--- a/backend/monitoring.py
+++ b/backend/monitoring.py
@@ -1,0 +1,57 @@
+import asyncio
+import logging
+
+import httpx
+
+from yaml_models import YamlService
+
+logger = logging.getLogger(__name__)
+
+_status_cache: dict[str, str] = {}
+
+
+def get_status(name: str) -> str:
+    return _status_cache.get(name, "unknown")
+
+
+async def _check_one(svc: YamlService) -> None:
+    url = svc.monitor_url
+    try:
+        async with httpx.AsyncClient(timeout=svc.monitor_timeout) as client:
+            for attempt in range(svc.monitor_retries + 1):
+                try:
+                    resp = await client.get(url)
+                    ok = resp.status_code == svc.monitor_expect_status
+                    if ok and svc.monitor_expect_body:
+                        ok = svc.monitor_expect_body in resp.text
+                    _status_cache[svc.name] = "online" if ok else "offline"
+                    logger.debug("Monitor %s -> %s", svc.name, _status_cache[svc.name])
+                    return
+                except httpx.RequestError:
+                    if attempt < svc.monitor_retries:
+                        await asyncio.sleep(1)
+            _status_cache[svc.name] = "offline"
+    except Exception as exc:
+        logger.warning("Monitor check failed for '%s': %s", svc.name, exc)
+        _status_cache[svc.name] = "offline"
+
+
+async def run_monitoring_loop(services: list[YamlService]) -> None:
+    monitorable = [s for s in services if s.monitor and not s.use_docker_health and s.monitor_url]
+    if not monitorable:
+        logger.info("No HTTP-monitorable services configured — monitoring loop idle")
+        return
+
+    logger.info("Starting monitoring loop for: %s", [s.name for s in monitorable])
+    last_check: dict[str, float] = {}
+
+    while True:
+        now = asyncio.get_event_loop().time()
+        pending = []
+        for svc in monitorable:
+            if now - last_check.get(svc.name, 0) >= svc.monitor_interval:
+                pending.append(_check_one(svc))
+                last_check[svc.name] = now
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        await asyncio.sleep(10)

--- a/backend/services.example.yaml
+++ b/backend/services.example.yaml
@@ -37,6 +37,8 @@
   icon: pickaxe
   # action-url is the base URL prepended to all action endpoints (except href actions).
   action-url: http://localhost:8080
+  # action-timeout: seconds to wait for an action response (default: 30)
+  action-timeout: 30
   actions:
     - label: Dashboard
       icon: layout-dashboard

--- a/backend/upstream.py
+++ b/backend/upstream.py
@@ -29,6 +29,7 @@ def call_upstream(
     label: str = "",
     headers: dict | None = None,
     body: dict | None = None,
+    timeout: float | None = None,
 ) -> ActionResult:
     """Call an upstream service with any HTTP method and map exceptions to ActionResult."""
     client = http_client.get()
@@ -41,6 +42,8 @@ def call_upstream(
             kwargs["headers"] = headers
         if body is not None:
             kwargs["json"] = body
+        if timeout is not None:
+            kwargs["timeout"] = timeout
         response = client.request(method_upper, url, **kwargs)
         response.raise_for_status()
         return ActionResult(success=True)

--- a/backend/yaml_models.py
+++ b/backend/yaml_models.py
@@ -17,6 +17,7 @@ class YamlService(BaseModel):
     url: str | None = None
     action_url: str | None = None
     action_headers: dict[str, str] | None = None
+    action_timeout: int = 30
     docker_container: str | None = None
     monitor: bool = False
     monitor_interval: int = 60


### PR DESCRIPTION
## Summary

- **Action timeout regression**: proxy action calls were using the global 5s httpx timeout, too short for endpoints that make external API calls (Epic Games API, Discord webhooks). Default raised to 30s, configurable per-service via `action-timeout` in the YAML.
- **Status regression**: migrating away from hardcoded service modules dropped the custom health check in `free_games_notifier`. Added a proper background monitoring loop that reads from the declarative YAML config.

## What changed

**`backend/yaml_models.py`**
- `action_timeout: int = 30` added to `YamlService`

**`backend/upstream.py`**
- `call_upstream()` accepts an optional `timeout` parameter passed as a per-request override

**`backend/config_service.py`**
- `_make_handler()` captures `svc.action_timeout` and passes it to `call_upstream`
- `yaml_to_card()` reads status from `monitoring.get_status()` instead of hard-coding `"unknown"`

**`backend/monitoring.py`** _(new)_
- Async background loop polling each service's `monitor-url` at `monitor-interval`
- Respects `monitor-retries`, `monitor-timeout`, `monitor-expect-status`, `monitor-expect-body`
- Skips services with `use-docker-health: true` (pending issues #36-37)
- Exposes `get_status(name) -> str` consumed by `yaml_to_card()`

**`backend/main.py`**
- Lifespan starts `run_monitoring_loop()` as an asyncio task and cancels it on shutdown

**`backend/services.example.yaml`**
- Documents `action-timeout` field

## Notes for reviewer

To restore "online"/"offline" status for Free Games Notifier, add to `config/services.yaml`:
```yaml
monitor: true
monitor-url: ${FREE_GAMES_NOTIFIER_URL}/health
monitor-expect-status: 200
```
Services with `use-docker-health: true` stay `"unknown"` until Docker integration lands (issues #36-37).