### PR TITLE
feat: GET /config and PUT /config endpoints

### DIFF
--- a/backend/config_loader.py
+++ b/backend/config_loader.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG_PATH = _PROJECT_ROOT / "config" / "services.yaml"
 EXAMPLE_PATH = _BACKEND_DIR / "services.example.yaml"
 
 _services: list[YamlService] = []
+_config_path: Path = DEFAULT_CONFIG_PATH
 
 _ENV_VAR_RE = re.compile(r"\$\{(\w+)\}")
 
@@ -75,8 +76,10 @@ def _bootstrap_config(config_path: Path) -> None:
 
 
 def load_config() -> None:
+    global _config_path
     config_env = os.getenv("SERVICES_CONFIG")
     config_path = Path(config_env.strip()) if config_env and config_env.strip() else DEFAULT_CONFIG_PATH
+    _config_path = config_path
 
     if not config_path.exists():
         _bootstrap_config(config_path)
@@ -124,3 +127,25 @@ def load_config() -> None:
 
 def get_services() -> list[YamlService]:
     return list(_services)
+
+
+def _to_yaml_dict(svc: YamlService) -> dict:
+    raw = svc.model_dump(exclude_none=True)
+
+    def _rename(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k.replace("_", "-"): _rename(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [_rename(item) for item in obj]
+        return obj
+
+    return _rename(raw)
+
+
+def save_config(services: list[YamlService]) -> None:
+    data = [_to_yaml_dict(svc) for svc in services]
+    yaml_text = yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    _config_path.write_text(yaml_text)
+    global _services
+    _services = services
+    logger.info("Saved %d service(s) to %s", len(_services), _config_path)

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ import config_loader
 from config_service import build_config_router, yaml_to_card
 from models import Service
 from monitoring import run_monitoring_loop
+from yaml_models import YamlService
 
 load_dotenv()
 
@@ -58,7 +59,7 @@ app = FastAPI(lifespan=lifespan, dependencies=[Security(verify_api_key)])
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
-    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_methods=["GET", "POST", "PUT", "OPTIONS"],
     allow_headers=["*"],
 )
 
@@ -66,3 +67,14 @@ app.add_middleware(
 @app.get("/services", response_model=list[Service])
 def get_services() -> list[Service]:
     return [yaml_to_card(svc) for svc in config_loader.get_services()]
+
+
+@app.get("/config", response_model=list[YamlService])
+def get_config() -> list[YamlService]:
+    return config_loader.get_services()
+
+
+@app.put("/config", response_model=list[YamlService])
+def put_config(services: list[YamlService]) -> list[YamlService]:
+    config_loader.save_config(services)
+    return config_loader.get_services()


### PR DESCRIPTION
Part of #39 (Admin UI). Closes #44, closes #45.

## What changed

**`backend/config_loader.py`**
- `_config_path` module variable tracks the resolved path from `load_config()` so `save_config()` always writes back to the same file
- `save_config(services)`: converts `list[YamlService]` → YAML dict (underscore→hyphen keys, `exclude_none=True`), writes to disk, updates in-memory cache

**`backend/main.py`**
- `GET /config` → returns `list[YamlService]` from in-memory cache (no disk I/O per call)
- `PUT /config` → validates incoming `list[YamlService]`, calls `save_config()`, returns the updated list
- Added `PUT` to CORS allowed methods

## Test plan
- [ ] `GET /config` returns all 13 services with correct field names (hyphenated? → no, Pydantic uses underscores in JSON)
- [ ] `PUT /config` with one service removed → 12 services saved to disk and returned
- [ ] `PUT /config` with invalid payload → FastAPI returns 422 automatically (Pydantic validation)
- [ ] After `PUT /config`, `GET /services` reflects the new service list