### PR TITLE
fix: dynamic icon lookup from lucide-react

### DIFF
--- a/src/utils/icons.jsx
+++ b/src/utils/icons.jsx
@@ -1,73 +1,26 @@
-import { 
-    Bell, 
-    BellRing,
-    RefreshCw, 
-    Play, 
-    Square, 
-    RotateCcw, 
-    Terminal, 
-    Globe, 
-    Settings, 
-    AlertTriangle,
-    Send,
-    SendHorizontal,
-    Pickaxe, 
-    Loader,
-    CircleAlert,
-    PackageOpen,
-    LayoutDashboard,
-    FolderGit2,
-    ShieldCheck,
-    ShieldCog,
-    ExternalLink,
-    Container,
-    Activity,
-    Home,
-    Cloud,
-    Server,
-    BarChart2,
-    GitBranch,
-    Bookmark,
-    Zap,
-    Network,
-} from "lucide-react"
+import * as LucideIcons from "lucide-react"
 
-const icons = {
-    "bell": Bell,
-    "bell-ring": BellRing,
-    "refresh": RefreshCw,
-    "play": Play,
-    "stop": Square,
-    "restart": RotateCcw,
-    "terminal": Terminal,
-    "globe": Globe,
-    "settings": Settings,
-    "alert": AlertTriangle,
-    "send": Send,
-    "send-horizontal": SendHorizontal,
-    "pickaxe": Pickaxe,
-    "loader": Loader,
-    "error": CircleAlert,
-    "empty": PackageOpen,
-    "dashboard": LayoutDashboard,
-    "github": FolderGit2,
-    "shield-check": ShieldCheck,
-    "shield-cog": ShieldCog,
-    "external-link": ExternalLink,
-    "container": Container,
-    "activity": Activity,
-    "home": Home,
-    "cloud": Cloud,
-    "server": Server,
-    "bar-chart": BarChart2,
-    "git-branch": GitBranch,
-    "bookmark": Bookmark,
-    "zap": Zap,
-    "network": Network,
+// Names that don't directly match a Lucide icon (kebab-case → PascalCase would fail)
+const ALIASES = {
+    "dashboard":  "LayoutDashboard",
+    "github":     "FolderGit2",
+    "bar-chart":  "BarChart2",
+    "error":      "CircleAlert",
+    "empty":      "PackageOpen",
+    "refresh":    "RefreshCw",
+    "stop":       "Square",
+    "restart":    "RotateCcw",
+    "alert":      "AlertTriangle",
+}
+
+function toPascalCase(str) {
+    return str.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join("")
 }
 
 export function getIcon(name, props = {}) {
-    const Icon = icons[name]
+    if (!name) return null
+    const pascalName = ALIASES[name] ?? toPascalCase(name)
+    const Icon = LucideIcons[pascalName]
     if (!Icon) return null
     return <Icon size={16} {...props} />
 }


### PR DESCRIPTION
## Problem
`icons.jsx` had a hardcoded map of ~25 icon names. Any icon not in the list silently returned `null`, making it impossible to use arbitrary Lucide icons from the YAML config without editing frontend code.

## Fix
Replace the static map with a dynamic lookup:
1. Convert kebab-case name → PascalCase (`"bell-ring"` → `"BellRing"`)
2. Look up directly in `import * as LucideIcons from "lucide-react"`
3. A small `ALIASES` map handles legacy names that don't map 1:1 (e.g. `"dashboard"` → `"LayoutDashboard"`)

Any icon name from https://lucide.dev/icons now works without touching frontend code.

## Trade-off
Bundle size increases (~450 KB → ~809 KB gzipped: 215 KB) because `import *` pulls in all ~1400 Lucide icons. Acceptable for a self-hosted dashboard.