### PR TITLE
feat: admin UI — service list and edit form

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    location ^~ /config {
+        proxy_pass http://apollo-server-dashboard-backend:8001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     # Serve the React SPA — fallback to index.html for client-side routing
     location / {
         try_files $uri $uri/ /index.html;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import ServiceCard from "./components/ServiceCard"
 import ActionPanel from "./components/ActionPanel"
+import AdminPanel from "./components/AdminPanel"
 import Login from "./components/Login"
 import { getIcon } from "./utils/icons"
 import { safeLocalStorage, safeSessionStorage } from "./utils/storage"
@@ -17,6 +18,7 @@ function App() {
     () => safeLocalStorage.getItem("apiKey") || safeSessionStorage.getItem("apiKey") || ""
   )
   const [authError, setAuthError] = useState(false)
+  const [adminOpen, setAdminOpen] = useState(false)
 
   const handleLogin = (key, rememberMe) => {
     setLoading(true)
@@ -141,6 +143,9 @@ function App() {
               Synced {lastUpdated.toLocaleTimeString()}
             </span>
           )}
+          <button className="icon-btn" onClick={() => setAdminOpen(true)} title="Config">
+            {getIcon("settings", { size: 16 })}
+          </button>
           <button className="logout-btn" onClick={handleLogout}>
             Logout
           </button>
@@ -181,9 +186,15 @@ function App() {
         ))}
       </div>
       {selectedService && (
-        <ActionPanel 
-          service={selectedService} 
-          onClose={handleClosePanel} 
+        <ActionPanel
+          service={selectedService}
+          onClose={handleClosePanel}
+          apiKey={apiKey}
+        />
+      )}
+      {adminOpen && (
+        <AdminPanel
+          onClose={() => setAdminOpen(false)}
           apiKey={apiKey}
         />
       )}

--- a/src/components/AdminPanel.css
+++ b/src/components/AdminPanel.css
@@ -1,0 +1,251 @@
+.admin-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--darkGray);
+    z-index: 100;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.admin-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+    flex-shrink: 0;
+}
+
+.admin-header-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.admin-header h2 {
+    font-family: monospace;
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--blueishWhite);
+    margin: 0;
+}
+
+.admin-add-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: none;
+    border: 0.5px solid var(--blue);
+    border-radius: 6px;
+    color: var(--blue);
+    font-family: monospace;
+    font-size: 12px;
+    padding: 7px 14px;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.admin-add-btn:hover {
+    background: rgba(64, 156, 255, 0.1);
+}
+
+.admin-error {
+    font-family: monospace;
+    font-size: 12px;
+    color: var(--red);
+    margin: 0 0 12px;
+}
+
+.admin-state {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: monospace;
+    font-size: 12px;
+    color: rgba(250, 250, 255, 0.35);
+}
+
+.admin-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.admin-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--blueishDarkGray);
+    border: 0.5px solid #2a2d30;
+    border-radius: 8px;
+    padding: 12px 16px;
+    transition: border-color 0.15s;
+}
+
+.admin-row:hover {
+    border-color: rgba(250, 250, 255, 0.1);
+}
+
+.admin-row-icon {
+    color: rgba(250, 250, 255, 0.5);
+    flex-shrink: 0;
+    width: 20px;
+    display: flex;
+    justify-content: center;
+}
+
+.admin-row-name {
+    font-family: monospace;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--blueishWhite);
+    width: 160px;
+    flex-shrink: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.admin-row-url {
+    font-family: monospace;
+    font-size: 11px;
+    color: rgba(250, 250, 255, 0.3);
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.admin-row-actions {
+    font-family: monospace;
+    font-size: 11px;
+    color: rgba(250, 250, 255, 0.25);
+    width: 60px;
+    flex-shrink: 0;
+    text-align: right;
+}
+
+.admin-row-btns {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.admin-btn {
+    background: none;
+    border: 0.5px solid #2a2d30;
+    border-radius: 6px;
+    font-family: monospace;
+    font-size: 11px;
+    padding: 5px 12px;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.admin-btn.edit {
+    color: rgba(250, 250, 255, 0.5);
+}
+
+.admin-btn.edit:hover {
+    border-color: rgba(250, 250, 255, 0.3);
+    color: var(--blueishWhite);
+}
+
+.admin-btn.delete {
+    color: rgba(255, 80, 80, 0.5);
+}
+
+.admin-btn.delete:hover {
+    border-color: var(--red);
+    color: var(--red);
+}
+
+.admin-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+/* Reuse confirm styles from ActionPanel */
+.confirm-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(11, 13, 15, 0.7);
+    backdrop-filter: blur(4px);
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.confirm-box {
+    background: var(--blueishDarkGray);
+    border: 0.5px solid #2a2d30;
+    border-radius: 8px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    min-width: 280px;
+}
+
+.confirm-message {
+    font-family: monospace;
+    font-size: 13px;
+    color: var(--blueishWhite);
+    margin: 0;
+}
+
+.confirm-message strong {
+    color: white;
+}
+
+.confirm-buttons {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.confirm-cancel {
+    background: none;
+    border: 0.5px solid #2a2d30;
+    border-radius: 6px;
+    color: rgba(250, 250, 255, 0.5);
+    font-family: monospace;
+    font-size: 12px;
+    padding: 8px 16px;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+}
+
+.confirm-cancel:hover {
+    border-color: rgba(250, 250, 255, 0.3);
+    color: var(--blueishWhite);
+}
+
+.confirm-ok {
+    background: none;
+    border: 0.5px solid var(--blue);
+    border-radius: 6px;
+    color: var(--blue);
+    font-family: monospace;
+    font-size: 12px;
+    padding: 8px 16px;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.confirm-ok:hover {
+    background: rgba(64, 156, 255, 0.1);
+}
+
+.confirm-ok.danger {
+    border-color: var(--red);
+    color: var(--red);
+}
+
+.confirm-ok.danger:hover {
+    background: rgba(255, 16, 64, 0.1);
+}

--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react"
+import { getIcon } from "../utils/icons"
+import ServiceForm from "./ServiceForm"
+import "./AdminPanel.css"
+
+function AdminPanel({ onClose, apiKey }) {
+    const [config, setConfig] = useState(null)
+    const [loading, setLoading] = useState(true)
+    const [saving, setSaving] = useState(false)
+    const [error, setError] = useState(null)
+    const [editingIndex, setEditingIndex] = useState(null) // null=list, "new"=add, number=edit
+    const [deleteIndex, setDeleteIndex] = useState(null)
+
+    useEffect(() => {
+        const handleKey = (e) => { if (e.key === "Escape") onClose() }
+        window.addEventListener("keydown", handleKey)
+        return () => window.removeEventListener("keydown", handleKey)
+    }, [onClose])
+
+    useEffect(() => {
+        fetch("/config", { headers: { "X-API-Key": apiKey } })
+            .then(res => res.json())
+            .then(data => { setConfig(data); setLoading(false) })
+            .catch(err => { setError(err.message); setLoading(false) })
+    }, [apiKey])
+
+    function putConfig(updated) {
+        setSaving(true)
+        setError(null)
+        return fetch("/config", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json", "X-API-Key": apiKey },
+            body: JSON.stringify(updated),
+        })
+            .then(res => {
+                if (!res.ok) return res.json().then(d => { throw new Error(d.detail || res.statusText) })
+                return res.json()
+            })
+            .then(data => { setConfig(data); setSaving(false) })
+            .catch(err => { setError(err.message); setSaving(false) })
+    }
+
+    function handleSave(service) {
+        const updated = editingIndex === "new"
+            ? [...config, service]
+            : config.map((s, i) => i === editingIndex ? service : s)
+        putConfig(updated).then(() => setEditingIndex(null))
+    }
+
+    function handleDelete(index) {
+        putConfig(config.filter((_, i) => i !== index))
+            .then(() => setDeleteIndex(null))
+    }
+
+    if (editingIndex !== null) {
+        return (
+            <ServiceForm
+                service={editingIndex === "new" ? null : config[editingIndex]}
+                onSave={handleSave}
+                onCancel={() => setEditingIndex(null)}
+                saving={saving}
+            />
+        )
+    }
+
+    return (
+        <div className="admin-backdrop">
+            <div className="admin-header">
+                <div className="admin-header-left">
+                    <button className="panel-back" onClick={onClose}>← Back</button>
+                    <h2>Config</h2>
+                </div>
+                <button className="admin-add-btn" onClick={() => setEditingIndex("new")}>
+                    {getIcon("plus", { size: 14 })} New service
+                </button>
+            </div>
+
+            {error && <p className="admin-error">{error}</p>}
+
+            {loading && (
+                <div className="admin-state">{getIcon("loader", { size: 16, className: "spin" })} Loading…</div>
+            )}
+
+            {!loading && config && (
+                <div className="admin-list">
+                    {config.map((svc, i) => (
+                        <div key={i} className="admin-row">
+                            <span className="admin-row-icon">
+                                {getIcon(svc.icon, { size: 16 })}
+                            </span>
+                            <span className="admin-row-name">{svc.name}</span>
+                            <span className="admin-row-url">{svc.url || svc.action_url || "—"}</span>
+                            <span className="admin-row-actions">
+                                {svc.actions?.length ? `${svc.actions.length} action${svc.actions.length > 1 ? "s" : ""}` : ""}
+                            </span>
+                            <div className="admin-row-btns">
+                                <button className="admin-btn edit" onClick={() => setEditingIndex(i)} disabled={saving}>
+                                    Edit
+                                </button>
+                                <button className="admin-btn delete" onClick={() => setDeleteIndex(i)} disabled={saving}>
+                                    Delete
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {deleteIndex !== null && (
+                <div className="confirm-backdrop" onClick={() => setDeleteIndex(null)}>
+                    <div className="confirm-box" onClick={e => e.stopPropagation()}>
+                        <p className="confirm-message">
+                            Delete <strong>{config[deleteIndex]?.name}</strong>?
+                        </p>
+                        <div className="confirm-buttons">
+                            <button className="confirm-cancel" onClick={() => setDeleteIndex(null)}>Cancel</button>
+                            <button className="confirm-ok danger" onClick={() => handleDelete(deleteIndex)} disabled={saving}>
+                                {saving ? "Deleting…" : "Delete"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+export default AdminPanel

--- a/src/components/ServiceForm.css
+++ b/src/components/ServiceForm.css
@@ -1,0 +1,250 @@
+.form-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--darkGray);
+    z-index: 110;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.service-form {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 24px;
+}
+
+.form-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 20px;
+    flex-shrink: 0;
+}
+
+.form-header h2 {
+    font-family: monospace;
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--blueishWhite);
+    margin: 0;
+}
+
+.form-body {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding-bottom: 8px;
+}
+
+.form-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.form-section h3 {
+    font-family: monospace;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(250, 250, 255, 0.3);
+    margin: 0;
+    padding-bottom: 6px;
+    border-bottom: 0.5px solid #2a2d30;
+}
+
+.form-row {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.form-row .field {
+    flex: 1;
+    min-width: 140px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.field-label {
+    font-family: monospace;
+    font-size: 10px;
+    color: rgba(250, 250, 255, 0.35);
+    letter-spacing: 0.05em;
+}
+
+.field input,
+.field textarea,
+.field select {
+    background: var(--blueishDarkGray);
+    border: 0.5px solid #2a2d30;
+    border-radius: 6px;
+    color: var(--blueishWhite);
+    font-family: monospace;
+    font-size: 12px;
+    padding: 8px 10px;
+    outline: none;
+    transition: border-color 0.15s;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.field input:focus,
+.field textarea:focus,
+.field select:focus {
+    border-color: var(--blue);
+}
+
+.field textarea {
+    resize: vertical;
+    min-height: 54px;
+}
+
+.field select {
+    appearance: none;
+    cursor: pointer;
+}
+
+.field-error {
+    font-family: monospace;
+    font-size: 10px;
+    color: var(--red);
+}
+
+.icon-input {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    background: var(--blueishDarkGray);
+    border: 0.5px solid #2a2d30;
+    border-radius: 6px;
+    transition: border-color 0.15s;
+}
+
+.icon-input:focus-within {
+    border-color: var(--blue);
+}
+
+.icon-preview {
+    padding: 0 8px;
+    color: rgba(250, 250, 255, 0.4);
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    min-width: 30px;
+    justify-content: center;
+}
+
+.icon-input input {
+    border: none;
+    background: transparent;
+    flex: 1;
+    padding: 8px 10px 8px 0;
+}
+
+.icon-input input:focus {
+    border: none;
+}
+
+.toggle-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: monospace;
+    font-size: 12px;
+    color: var(--blueishWhite);
+    cursor: pointer;
+}
+
+.toggle-label.small {
+    font-size: 11px;
+    color: rgba(250, 250, 255, 0.6);
+}
+
+.toggle-label input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+    accent-color: var(--blue);
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+/* Action blocks */
+.action-form-block {
+    background: var(--blueishDarkGray);
+    border: 0.5px solid #2a2d30;
+    border-radius: 8px;
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.action-form-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.action-form-num {
+    font-family: monospace;
+    font-size: 11px;
+    color: rgba(250, 250, 255, 0.3);
+}
+
+.action-remove-btn {
+    background: none;
+    border: 0.5px solid rgba(255, 80, 80, 0.3);
+    border-radius: 5px;
+    color: rgba(255, 80, 80, 0.5);
+    font-family: monospace;
+    font-size: 10px;
+    padding: 3px 8px;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+}
+
+.action-remove-btn:hover {
+    border-color: var(--red);
+    color: var(--red);
+}
+
+.add-action-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    align-self: flex-start;
+    background: none;
+    border: 0.5px dashed #2a2d30;
+    border-radius: 6px;
+    color: rgba(250, 250, 255, 0.3);
+    font-family: monospace;
+    font-size: 11px;
+    padding: 7px 14px;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+}
+
+.add-action-btn:hover {
+    border-color: rgba(250, 250, 255, 0.2);
+    color: rgba(250, 250, 255, 0.6);
+}
+
+.form-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 16px;
+    flex-shrink: 0;
+    border-top: 0.5px solid #2a2d30;
+    margin-top: 8px;
+}

--- a/src/components/ServiceForm.jsx
+++ b/src/components/ServiceForm.jsx
@@ -1,0 +1,274 @@
+import { useState } from "react"
+import { getIcon } from "../utils/icons"
+import "./ServiceForm.css"
+
+const METHODS = ["href", "GET", "POST", "PUT", "DELETE", "PATCH"]
+
+const EMPTY_ACTION = { label: "", icon: "", endpoint: "", method: "POST", body: "", confirm: false }
+
+const EMPTY_SERVICE = {
+    name: "", icon: "", url: "", action_url: "", action_timeout: 30,
+    action_headers: {}, docker_container: "",
+    monitor: false, monitor_url: "", monitor_interval: 60, monitor_timeout: 5,
+    monitor_retries: 3, monitor_expect_status: 200, monitor_expect_body: "",
+    use_docker_health: false, actions: [],
+}
+
+function headersToText(headers) {
+    if (!headers) return ""
+    return Object.entries(headers).map(([k, v]) => `${k}: ${v}`).join("\n")
+}
+
+function textToHeaders(text) {
+    const result = {}
+    for (const line of text.split("\n")) {
+        const idx = line.indexOf(":")
+        if (idx < 1) continue
+        const key = line.slice(0, idx).trim()
+        const val = line.slice(idx + 1).trim()
+        if (key) result[key] = val
+    }
+    return result
+}
+
+function actionToForm(action) {
+    return { ...action, body: action.body ? JSON.stringify(action.body, null, 2) : "" }
+}
+
+function formToAction(action) {
+    let body = null
+    if (action.body?.trim()) {
+        try { body = JSON.parse(action.body) } catch { body = null }
+    }
+    return { ...action, body }
+}
+
+function ServiceForm({ service, onSave, onCancel, saving }) {
+    const init = service
+        ? { ...service, action_headers: service.action_headers || {}, actions: (service.actions || []).map(actionToForm) }
+        : { ...EMPTY_SERVICE }
+
+    const [form, setForm] = useState(init)
+    const [headersText, setHeadersText] = useState(headersToText(init.action_headers))
+    const [errors, setErrors] = useState({})
+
+    function set(field, value) {
+        setForm(f => ({ ...f, [field]: value }))
+    }
+
+    function setAction(i, field, value) {
+        setForm(f => {
+            const actions = [...f.actions]
+            actions[i] = { ...actions[i], [field]: value }
+            return { ...f, actions }
+        })
+    }
+
+    function addAction() {
+        setForm(f => ({ ...f, actions: [...f.actions, { ...EMPTY_ACTION }] }))
+    }
+
+    function removeAction(i) {
+        setForm(f => ({ ...f, actions: f.actions.filter((_, idx) => idx !== i) }))
+    }
+
+    function validate() {
+        const e = {}
+        if (!form.name.trim()) e.name = "Required"
+        for (const [i, a] of form.actions.entries()) {
+            if (!a.label.trim()) e[`action_${i}_label`] = "Required"
+            if (!a.endpoint.trim()) e[`action_${i}_endpoint`] = "Required"
+            if (a.body?.trim()) {
+                try { JSON.parse(a.body) } catch { e[`action_${i}_body`] = "Invalid JSON" }
+            }
+        }
+        return e
+    }
+
+    function handleSubmit(e) {
+        e.preventDefault()
+        const errs = validate()
+        if (Object.keys(errs).length) { setErrors(errs); return }
+
+        const service = {
+            ...form,
+            name: form.name.trim(),
+            icon: form.icon.trim() || null,
+            url: form.url.trim() || null,
+            action_url: form.action_url.trim() || null,
+            docker_container: form.docker_container.trim() || null,
+            monitor_url: form.monitor_url.trim() || null,
+            monitor_expect_body: form.monitor_expect_body.trim() || null,
+            action_headers: textToHeaders(headersText) || null,
+            actions: form.actions.length ? form.actions.map(formToAction) : null,
+        }
+        onSave(service)
+    }
+
+    return (
+        <div className="form-backdrop">
+            <form className="service-form" onSubmit={handleSubmit} noValidate>
+                <div className="form-header">
+                    <h2>{service ? `Edit — ${service.name}` : "New service"}</h2>
+                    <button type="button" className="panel-back" onClick={onCancel}>← Cancel</button>
+                </div>
+
+                <div className="form-body">
+                    {/* Basic */}
+                    <section className="form-section">
+                        <h3>Basic</h3>
+                        <div className="form-row">
+                            <Field label="Name *" error={errors.name}>
+                                <input value={form.name} onChange={e => set("name", e.target.value)} placeholder="My Service" />
+                            </Field>
+                            <Field label="Icon">
+                                <div className="icon-input">
+                                    <span className="icon-preview">{getIcon(form.icon, { size: 14 })}</span>
+                                    <input value={form.icon} onChange={e => set("icon", e.target.value)} placeholder="server" />
+                                </div>
+                            </Field>
+                        </div>
+                        <Field label="URL">
+                            <input value={form.url} onChange={e => set("url", e.target.value)} placeholder="https://service.example.com" />
+                        </Field>
+                    </section>
+
+                    {/* Upstream actions */}
+                    <section className="form-section">
+                        <h3>Upstream</h3>
+                        <div className="form-row">
+                            <Field label="Action URL">
+                                <input value={form.action_url} onChange={e => set("action_url", e.target.value)} placeholder="http://service:8000" />
+                            </Field>
+                            <Field label="Action timeout (s)">
+                                <input type="number" min="1" value={form.action_timeout} onChange={e => set("action_timeout", parseInt(e.target.value) || 30)} />
+                            </Field>
+                        </div>
+                        <Field label="Action headers (one per line: Key: Value)">
+                            <textarea
+                                rows={3}
+                                value={headersText}
+                                onChange={e => setHeadersText(e.target.value)}
+                                placeholder={"X-API-Key: secret\nContent-Type: application/json"}
+                            />
+                        </Field>
+                        <Field label="Docker container name">
+                            <input value={form.docker_container} onChange={e => set("docker_container", e.target.value)} placeholder="my-container" />
+                        </Field>
+                    </section>
+
+                    {/* Monitoring */}
+                    <section className="form-section">
+                        <h3>
+                            <label className="toggle-label">
+                                <input type="checkbox" checked={form.monitor} onChange={e => set("monitor", e.target.checked)} />
+                                Monitoring
+                            </label>
+                        </h3>
+                        {form.monitor && (
+                            <>
+                                <label className="toggle-label small">
+                                    <input type="checkbox" checked={form.use_docker_health} onChange={e => set("use_docker_health", e.target.checked)} />
+                                    Use Docker health
+                                </label>
+                                {!form.use_docker_health && (
+                                    <>
+                                        <Field label="Monitor URL *">
+                                            <input value={form.monitor_url} onChange={e => set("monitor_url", e.target.value)} placeholder="https://service.example.com/health" />
+                                        </Field>
+                                        <div className="form-row">
+                                            <Field label="Interval (s)">
+                                                <input type="number" min="5" value={form.monitor_interval} onChange={e => set("monitor_interval", parseInt(e.target.value) || 60)} />
+                                            </Field>
+                                            <Field label="Timeout (s)">
+                                                <input type="number" min="1" value={form.monitor_timeout} onChange={e => set("monitor_timeout", parseInt(e.target.value) || 5)} />
+                                            </Field>
+                                            <Field label="Retries">
+                                                <input type="number" min="0" value={form.monitor_retries} onChange={e => set("monitor_retries", parseInt(e.target.value) || 3)} />
+                                            </Field>
+                                        </div>
+                                        <div className="form-row">
+                                            <Field label="Expect status">
+                                                <input type="number" value={form.monitor_expect_status} onChange={e => set("monitor_expect_status", parseInt(e.target.value) || 200)} />
+                                            </Field>
+                                            <Field label="Expect body contains">
+                                                <input value={form.monitor_expect_body} onChange={e => set("monitor_expect_body", e.target.value)} placeholder="OK" />
+                                            </Field>
+                                        </div>
+                                    </>
+                                )}
+                            </>
+                        )}
+                    </section>
+
+                    {/* Actions */}
+                    <section className="form-section">
+                        <h3>Actions</h3>
+                        {form.actions.map((action, i) => (
+                            <div key={i} className="action-form-block">
+                                <div className="action-form-header">
+                                    <span className="action-form-num">#{i + 1}</span>
+                                    <button type="button" className="action-remove-btn" onClick={() => removeAction(i)}>Remove</button>
+                                </div>
+                                <div className="form-row">
+                                    <Field label="Label *" error={errors[`action_${i}_label`]}>
+                                        <input value={action.label} onChange={e => setAction(i, "label", e.target.value)} placeholder="Trigger" />
+                                    </Field>
+                                    <Field label="Icon">
+                                        <div className="icon-input">
+                                            <span className="icon-preview">{getIcon(action.icon, { size: 14 })}</span>
+                                            <input value={action.icon} onChange={e => setAction(i, "icon", e.target.value)} placeholder="play" />
+                                        </div>
+                                    </Field>
+                                </div>
+                                <div className="form-row">
+                                    <Field label="Endpoint *" error={errors[`action_${i}_endpoint`]}>
+                                        <input value={action.endpoint} onChange={e => setAction(i, "endpoint", e.target.value)} placeholder="/trigger or https://example.com" />
+                                    </Field>
+                                    <Field label="Method">
+                                        <select value={action.method} onChange={e => setAction(i, "method", e.target.value)}>
+                                            {METHODS.map(m => <option key={m}>{m}</option>)}
+                                        </select>
+                                    </Field>
+                                </div>
+                                <div className="form-row">
+                                    <Field label="Body (JSON)" error={errors[`action_${i}_body`]}>
+                                        <textarea rows={2} value={action.body} onChange={e => setAction(i, "body", e.target.value)} placeholder='{"key": "value"}' />
+                                    </Field>
+                                    <Field label="">
+                                        <label className="toggle-label small" style={{ marginTop: 20 }}>
+                                            <input type="checkbox" checked={action.confirm} onChange={e => setAction(i, "confirm", e.target.checked)} />
+                                            Require confirm
+                                        </label>
+                                    </Field>
+                                </div>
+                            </div>
+                        ))}
+                        <button type="button" className="add-action-btn" onClick={addAction}>
+                            {getIcon("plus", { size: 13 })} Add action
+                        </button>
+                    </section>
+                </div>
+
+                <div className="form-footer">
+                    <button type="button" className="confirm-cancel" onClick={onCancel}>Cancel</button>
+                    <button type="submit" className="confirm-ok" disabled={saving}>
+                        {saving ? "Saving…" : "Save"}
+                    </button>
+                </div>
+            </form>
+        </div>
+    )
+}
+
+function Field({ label, error, children }) {
+    return (
+        <div className="field">
+            {label && <label className="field-label">{label}</label>}
+            {children}
+            {error && <span className="field-error">{error}</span>}
+        </div>
+    )
+}
+
+export default ServiceForm

--- a/src/index.css
+++ b/src/index.css
@@ -80,6 +80,21 @@ h1 {
   flex-shrink: 0;
 }
 
+.icon-btn {
+  background: none;
+  border: none;
+  color: rgba(250, 250, 255, 0.3);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+}
+
+.icon-btn:hover {
+  color: var(--blueishWhite);
+}
+
 .logout-btn {
   background: none;
   border: 0.5px solid #2a2d30;

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/services': 'http://localhost:8001',
+      '/config': 'http://localhost:8001',
     },
   },
 })


### PR DESCRIPTION
Closes #46, closes #47. Part of #39.

Requires PR #48 (GET/PUT /config endpoints) to be merged first.

## What's new

**Gear icon** in the dashboard header opens the admin panel.

**AdminPanel** (`src/components/AdminPanel.jsx`)
- Lists all services from `GET /config` with icon, name, URL, action count
- Edit button → opens ServiceForm pre-filled
- Delete button → confirm dialog → `PUT /config` with service removed
- New Service button → opens empty ServiceForm

**ServiceForm** (`src/components/ServiceForm.jsx`)
- Sections: Basic (name, icon, url), Upstream (action_url, timeout, headers, docker_container), Monitoring (toggle + conditional fields), Actions (add/remove inline)
- Icon field shows a live preview of the icon as you type
- Action body field is a JSON textarea with validation before submit
- All changes sent as a full `PUT /config` call

## Test plan
- [ ] Open admin panel via gear icon
- [ ] Edit an existing service (e.g. change icon) → save → verify change appears in dashboard on next poll
- [ ] Add a new service → save → appears in list
- [ ] Delete a service → confirm → removed from list
- [ ] Try saving with empty name → validation error shown inline
- [ ] Try saving action with invalid JSON body → validation error shown