### PR TITLE
fix: resolve null.trim crash and silent save failures in admin form

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import ServiceCard from "./components/ServiceCard"
 import ActionPanel from "./components/ActionPanel"
 import AdminPanel from "./components/AdminPanel"
@@ -19,6 +19,7 @@ function App() {
   )
   const [authError, setAuthError] = useState(false)
   const [adminOpen, setAdminOpen] = useState(false)
+  const fetchServicesRef = useRef(null)
 
   const handleLogin = (key, rememberMe) => {
     setLoading(true)
@@ -113,6 +114,7 @@ function App() {
         })
     }
 
+    fetchServicesRef.current = fetchServices
     fetchServices()
 
     const intervalId = setInterval(fetchServices, REFRESH_INTERVAL_MS)
@@ -196,6 +198,7 @@ function App() {
         <AdminPanel
           onClose={() => setAdminOpen(false)}
           apiKey={apiKey}
+          onConfigChanged={() => fetchServicesRef.current?.()}
         />
       )}
       

--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -3,11 +3,12 @@ import { getIcon } from "../utils/icons"
 import ServiceForm from "./ServiceForm"
 import "./AdminPanel.css"
 
-function AdminPanel({ onClose, apiKey }) {
+function AdminPanel({ onClose, apiKey, onConfigChanged }) {
     const [config, setConfig] = useState(null)
     const [loading, setLoading] = useState(true)
     const [saving, setSaving] = useState(false)
     const [error, setError] = useState(null)
+    const [formError, setFormError] = useState(null)
     const [editingIndex, setEditingIndex] = useState(null) // null=list, "new"=add, number=edit
     const [deleteIndex, setDeleteIndex] = useState(null)
 
@@ -27,6 +28,7 @@ function AdminPanel({ onClose, apiKey }) {
     function putConfig(updated) {
         setSaving(true)
         setError(null)
+        setFormError(null)
         return fetch("/config", {
             method: "PUT",
             headers: { "Content-Type": "application/json", "X-API-Key": apiKey },
@@ -36,20 +38,23 @@ function AdminPanel({ onClose, apiKey }) {
                 if (!res.ok) return res.json().then(d => { throw new Error(d.detail || res.statusText) })
                 return res.json()
             })
-            .then(data => { setConfig(data); setSaving(false) })
-            .catch(err => { setError(err.message); setSaving(false) })
+            .then(data => { setConfig(data); setSaving(false); onConfigChanged?.() })
+            .catch(err => { setSaving(false); throw err })
     }
 
     function handleSave(service) {
         const updated = editingIndex === "new"
             ? [...config, service]
             : config.map((s, i) => i === editingIndex ? service : s)
-        putConfig(updated).then(() => setEditingIndex(null))
+        putConfig(updated)
+            .then(() => setEditingIndex(null))
+            .catch(err => setFormError(err.message))
     }
 
     function handleDelete(index) {
         putConfig(config.filter((_, i) => i !== index))
             .then(() => setDeleteIndex(null))
+            .catch(err => setError(err.message))
     }
 
     if (editingIndex !== null) {
@@ -59,6 +64,7 @@ function AdminPanel({ onClose, apiKey }) {
                 onSave={handleSave}
                 onCancel={() => setEditingIndex(null)}
                 saving={saving}
+                error={formError}
             />
         )
     }

--- a/src/components/ServiceForm.css
+++ b/src/components/ServiceForm.css
@@ -242,9 +242,17 @@
 .form-footer {
     display: flex;
     justify-content: flex-end;
+    align-items: center;
     gap: 8px;
     padding-top: 16px;
     flex-shrink: 0;
     border-top: 0.5px solid #2a2d30;
     margin-top: 8px;
+}
+
+.form-footer-error {
+    flex: 1;
+    font-family: monospace;
+    font-size: 11px;
+    color: var(--red);
 }

--- a/src/components/ServiceForm.jsx
+++ b/src/components/ServiceForm.jsx
@@ -43,9 +43,20 @@ function formToAction(action) {
     return { ...action, body }
 }
 
-function ServiceForm({ service, onSave, onCancel, saving }) {
+function ServiceForm({ service, onSave, onCancel, saving, error }) {
     const init = service
-        ? { ...service, action_headers: service.action_headers || {}, actions: (service.actions || []).map(actionToForm) }
+        ? {
+            ...EMPTY_SERVICE,
+            ...service,
+            icon: service.icon ?? "",
+            url: service.url ?? "",
+            action_url: service.action_url ?? "",
+            docker_container: service.docker_container ?? "",
+            monitor_url: service.monitor_url ?? "",
+            monitor_expect_body: service.monitor_expect_body ?? "",
+            action_headers: service.action_headers ?? {},
+            actions: (service.actions ?? []).map(actionToForm),
+          }
         : { ...EMPTY_SERVICE }
 
     const [form, setForm] = useState(init)
@@ -251,6 +262,7 @@ function ServiceForm({ service, onSave, onCancel, saving }) {
                 </div>
 
                 <div className="form-footer">
+                    {error && <span className="form-footer-error">{error}</span>}
                     <button type="button" className="confirm-cancel" onClick={onCancel}>Cancel</button>
                     <button type="submit" className="confirm-ok" disabled={saving}>
                         {saving ? "Saving…" : "Save"}


### PR DESCRIPTION
## Summary
- **Root cause of server crash**: existing services have `null` for optional fields (`action_url`, `url`, `icon`, etc.) — the form initialized with those nulls, then `null.trim()` threw on submit
- **Silent save**: `putConfig` was catching errors and swallowing them, so `handleSave` always closed the form even on failure
- **No feedback on error**: errors were stored in `AdminPanel` state but invisible while the form was open

## Changes
- Coerce null optional fields to `""` via `??` when initializing `ServiceForm` from existing service data
- Re-throw errors in `putConfig` so `handleSave` only closes the form on success
- Show PUT errors inline in the `ServiceForm` footer
- Trigger an immediate `fetchServices()` after a successful save (via ref) so the dashboard grid updates without waiting for the next 30s poll

## Test plan
- [ ] Open Config → Edit an existing service → Save — should save without crash
- [ ] Verify form stays open and shows error message if the PUT fails
- [ ] Verify dashboard cards refresh immediately after a successful save

🤖 Generated with [Claude Code](https://claude.com/claude-code)