### PR TITLE
feat: Docker container status monitoring (#36 #37 #38)

### DIFF
--- a/backend/docker_client.py
+++ b/backend/docker_client.py
@@ -1,0 +1,32 @@
+import logging
+
+import docker
+import docker.errors
+
+logger = logging.getLogger(__name__)
+
+_client: docker.DockerClient | None = None
+
+
+def _get_client() -> docker.DockerClient:
+    global _client
+    if _client is None:
+        _client = docker.from_env()
+    return _client
+
+
+def get_container_status(container_name: str) -> str:
+    try:
+        container = _get_client().containers.get(container_name)
+        if container.status != "running":
+            return "offline"
+        health = container.attrs.get("State", {}).get("Health", {}).get("Status")
+        if health is not None:
+            return "online" if health == "healthy" else "offline"
+        return "online"
+    except docker.errors.NotFound:
+        logger.warning("Container '%s' not found", container_name)
+        return "unknown"
+    except Exception as exc:
+        logger.warning("Docker status check failed for '%s': %s", container_name, exc)
+        return "unknown"

--- a/backend/monitoring.py
+++ b/backend/monitoring.py
@@ -14,7 +14,7 @@ def get_status(name: str) -> str:
     return _status_cache.get(name, "unknown")
 
 
-async def _check_one(svc: YamlService) -> None:
+async def _check_http(svc: YamlService) -> None:
     url = svc.monitor_url
     try:
         async with httpx.AsyncClient(timeout=svc.monitor_timeout) as client:
@@ -36,21 +36,42 @@ async def _check_one(svc: YamlService) -> None:
         _status_cache[svc.name] = "offline"
 
 
+async def _check_docker(svc: YamlService) -> None:
+    try:
+        from docker_client import get_container_status
+        status = await asyncio.to_thread(get_container_status, svc.docker_container)
+        _status_cache[svc.name] = status
+        logger.debug("Docker monitor %s -> %s", svc.name, status)
+    except Exception as exc:
+        logger.warning("Docker check failed for '%s': %s", svc.name, exc)
+        _status_cache[svc.name] = "unknown"
+
+
 async def run_monitoring_loop(services: list[YamlService]) -> None:
-    monitorable = [s for s in services if s.monitor and not s.use_docker_health and s.monitor_url]
-    if not monitorable:
-        logger.info("No HTTP-monitorable services configured — monitoring loop idle")
+    http_services = [s for s in services if s.monitor and not s.use_docker_health and s.monitor_url]
+    docker_services = [s for s in services if s.monitor and s.use_docker_health and s.docker_container]
+
+    if not http_services and not docker_services:
+        logger.info("No monitorable services configured — monitoring loop idle")
         return
 
-    logger.info("Starting monitoring loop for: %s", [s.name for s in monitorable])
+    logger.info(
+        "Starting monitoring loop — HTTP: %s, Docker: %s",
+        [s.name for s in http_services],
+        [s.name for s in docker_services],
+    )
     last_check: dict[str, float] = {}
 
     while True:
         now = asyncio.get_event_loop().time()
         pending = []
-        for svc in monitorable:
+        for svc in http_services:
             if now - last_check.get(svc.name, 0) >= svc.monitor_interval:
-                pending.append(_check_one(svc))
+                pending.append(_check_http(svc))
+                last_check[svc.name] = now
+        for svc in docker_services:
+            if now - last_check.get(svc.name, 0) >= svc.monitor_interval:
+                pending.append(_check_docker(svc))
                 last_check[svc.name] = now
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
+docker==7.1.0
 fastapi==0.115.12
 httpx==0.28.1
 pydantic==2.12.5

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,6 +23,7 @@ services:
       - SERVICES_CONFIG=${SERVICES_CONFIG:-/app/config/services.yaml}
     volumes:
       - ./config:/app/config
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: unless-stopped
     networks:
       - apollo-server-network


### PR DESCRIPTION
Closes #36, #37, #38

## Summary
- Mount `/var/run/docker.sock` (read-only) into the backend container so it can query Docker
- Add `docker==7.1.0` Python SDK dependency
- New `docker_client.py` utility with `get_container_status(container_name)` → `"online"` / `"offline"` / `"unknown"` — respects Docker healthcheck status when configured on the container
- `monitoring.py` now handles both HTTP-based and Docker-based services in the same polling loop using each service's `monitor-interval`

## How it works
Services with `use-docker-health: true` and a `docker-container` name are monitored by inspecting the container state via the Docker socket instead of making an HTTP request. The container is `"online"` if it's running and healthy (or running with no healthcheck configured), `"offline"` otherwise, and `"unknown"` if the container name isn't found.

## Test plan
- [ ] Set `use-docker-health: true` and `docker-container: <name>` on a service in `config/services.yaml`
- [ ] `docker compose up -d` and verify the service card shows `online`
- [ ] Stop the container (`docker stop <name>`) and verify the card transitions to `offline` within one polling interval
- [ ] Use an unknown container name and verify the card shows `unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)