### PR TITLE
fix: require docker-container when use-docker-health is true

### DIFF
--- a/backend/yaml_models.py
+++ b/backend/yaml_models.py
@@ -39,9 +39,14 @@ class YamlService(BaseModel):
         return {k.replace("-", "_"): v for k, v in data.items()}
 
     @model_validator(mode="after")
-    def validate_monitor_url(self) -> "YamlService":
-        if self.monitor and not self.use_docker_health and not self.monitor_url:
-            raise ValueError(
-                f"Service '{self.name}': 'monitor-url' is required when 'monitor' is true and 'use-docker-health' is false"
-            )
+    def validate_monitor_config(self) -> "YamlService":
+        if self.monitor:
+            if self.use_docker_health and not self.docker_container:
+                raise ValueError(
+                    f"Service '{self.name}': 'docker-container' is required when 'use-docker-health' is true"
+                )
+            if not self.use_docker_health and not self.monitor_url:
+                raise ValueError(
+                    f"Service '{self.name}': 'monitor-url' is required when 'monitor' is true and 'use-docker-health' is false"
+                )
         return self


### PR DESCRIPTION
## Summary
- Without a `docker-container` name, enabling `use-docker-health` saves silently and the service stays `Unknown` forever with no error shown
- Now the PUT /config endpoint returns a 422 with a clear message if `use-docker-health: true` but `docker-container` is missing

## Test plan
- [ ] Enable "Use Docker health" without filling "Docker container name" → form should show a validation error on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)