### PR TITLE
fix: warn and skip invalid services on startup instead of crashing

### DIFF
--- a/backend/config_loader.py
+++ b/backend/config_loader.py
@@ -118,7 +118,10 @@ def load_config() -> None:
             errors.append(f"  Service '{name}':\n" + "\n".join(formatted_errors))
 
     if errors:
-        raise ValueError("Invalid service definitions in config:\n" + "\n".join(errors))
+        logger.warning(
+            "Skipping %d invalid service(s) from %s:\n%s",
+            len(errors), config_path, "\n".join(errors),
+        )
 
     global _services
     _services = services


### PR DESCRIPTION
## Problem
PR #53 added validation that `docker-container` is required when `use-docker-health: true`. But the startup code raises `ValueError` on any validation error, crashing the entire backend. If a service config is invalid (e.g. saved before the validation existed), the whole dashboard goes down and the user can't reach the Admin UI to fix it.

## Fix
Invalid services are now logged as warnings and skipped instead of crashing the backend. The dashboard starts normally with the valid services, and the user can open Config → edit the broken service → fix and save.

The PUT /config endpoint still validates strictly — you can't save a bad config through the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)