### PR TITLE
fix: monitoring loop reads live config instead of startup snapshot

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -44,7 +44,7 @@ async def lifespan(app: FastAPI):
     http_client.init()
     services = config_loader.get_services()
     app.include_router(build_config_router(services))
-    monitor_task = asyncio.create_task(run_monitoring_loop(services))
+    monitor_task = asyncio.create_task(run_monitoring_loop())
     yield
     monitor_task.cancel()
     try:

--- a/backend/monitoring.py
+++ b/backend/monitoring.py
@@ -3,6 +3,7 @@ import logging
 
 import httpx
 
+import config_loader
 from yaml_models import YamlService
 
 logger = logging.getLogger(__name__)
@@ -47,22 +48,14 @@ async def _check_docker(svc: YamlService) -> None:
         _status_cache[svc.name] = "unknown"
 
 
-async def run_monitoring_loop(services: list[YamlService]) -> None:
-    http_services = [s for s in services if s.monitor and not s.use_docker_health and s.monitor_url]
-    docker_services = [s for s in services if s.monitor and s.use_docker_health and s.docker_container]
-
-    if not http_services and not docker_services:
-        logger.info("No monitorable services configured — monitoring loop idle")
-        return
-
-    logger.info(
-        "Starting monitoring loop — HTTP: %s, Docker: %s",
-        [s.name for s in http_services],
-        [s.name for s in docker_services],
-    )
+async def run_monitoring_loop() -> None:
     last_check: dict[str, float] = {}
 
     while True:
+        services = config_loader.get_services()
+        http_services = [s for s in services if s.monitor and not s.use_docker_health and s.monitor_url]
+        docker_services = [s for s in services if s.monitor and s.use_docker_health and s.docker_container]
+
         now = asyncio.get_event_loop().time()
         pending = []
         for svc in http_services:


### PR DESCRIPTION
## Problem
The monitoring loop was started once at startup with a snapshot of services:
```python
services = config_loader.get_services()
monitor_task = asyncio.create_task(run_monitoring_loop(services))
```
Any service added or modified via PUT /config was invisible to the loop until the backend restarted, always showing `Unknown`.

## Fix
The loop now calls `config_loader.get_services()` on every iteration (~10s cycle), so config changes take effect without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)