### PR TITLE
fix: correctly grant appuser access to Docker socket at startup

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,3 +1,14 @@
 #!/bin/sh
 chown -R appuser:appuser /app/config
+
+if [ -S /var/run/docker.sock ]; then
+    DOCKER_GID=$(stat -c '%g' /var/run/docker.sock)
+    DOCKER_GROUP=$(getent group "$DOCKER_GID" 2>/dev/null | cut -d: -f1)
+    if [ -z "$DOCKER_GROUP" ]; then
+        groupadd --gid "$DOCKER_GID" docker-socket
+        DOCKER_GROUP=docker-socket
+    fi
+    usermod -aG "$DOCKER_GROUP" appuser
+fi
+
 exec gosu appuser uvicorn main:app --host 0.0.0.0 --port 8001


### PR DESCRIPTION
## Root cause
`groupadd -f` exits silently (success) without creating the target group when that GID already exists inside the container under a different name. The subsequent `usermod -aG docker-host appuser` then fails silently (group not found), leaving `appuser` without Docker socket access.

## Fix
Use `getent group <GID>` to look up the existing group name for the socket's GID. Add `appuser` to that group directly. Only create a new `docker-socket` group if no group with that GID exists yet.

## Test plan
- [ ] Merge, then `docker compose up -d --build` on the server
- [ ] Check logs — `PermissionError` warnings should be gone
- [ ] Dockge and Portainer should show `online`/`offline` instead of `unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)