### PR TITLE
feat: monitor_headers support for authenticated HTTP health checks

### DIFF
--- a/backend/monitoring.py
+++ b/backend/monitoring.py
@@ -17,11 +17,12 @@ def get_status(name: str) -> str:
 
 async def _check_http(svc: YamlService) -> None:
     url = svc.monitor_url
+    headers = dict(svc.monitor_headers) if svc.monitor_headers else {}
     try:
         async with httpx.AsyncClient(timeout=svc.monitor_timeout) as client:
             for attempt in range(svc.monitor_retries + 1):
                 try:
-                    resp = await client.get(url)
+                    resp = await client.get(url, headers=headers)
                     ok = resp.status_code == svc.monitor_expect_status
                     if ok and svc.monitor_expect_body:
                         ok = svc.monitor_expect_body in resp.text

--- a/backend/yaml_models.py
+++ b/backend/yaml_models.py
@@ -24,6 +24,7 @@ class YamlService(BaseModel):
     monitor_timeout: int = 5
     monitor_retries: int = 3
     monitor_url: str | None = None
+    monitor_headers: dict[str, str] | None = None
     monitor_expect_status: int = 200
     monitor_expect_body: str | None = None
     use_docker_health: bool = False

--- a/src/components/ServiceForm.jsx
+++ b/src/components/ServiceForm.jsx
@@ -9,7 +9,7 @@ const EMPTY_ACTION = { label: "", icon: "", endpoint: "", method: "POST", body: 
 const EMPTY_SERVICE = {
     name: "", icon: "", url: "", action_url: "", action_timeout: 30,
     action_headers: {}, docker_container: "",
-    monitor: false, monitor_url: "", monitor_interval: 60, monitor_timeout: 5,
+    monitor: false, monitor_url: "", monitor_headers: {}, monitor_interval: 60, monitor_timeout: 5,
     monitor_retries: 3, monitor_expect_status: 200, monitor_expect_body: "",
     use_docker_health: false, actions: [],
 }
@@ -55,12 +55,14 @@ function ServiceForm({ service, onSave, onCancel, saving, error }) {
             monitor_url: service.monitor_url ?? "",
             monitor_expect_body: service.monitor_expect_body ?? "",
             action_headers: service.action_headers ?? {},
+            monitor_headers: service.monitor_headers ?? {},
             actions: (service.actions ?? []).map(actionToForm),
           }
         : { ...EMPTY_SERVICE }
 
     const [form, setForm] = useState(init)
     const [headersText, setHeadersText] = useState(headersToText(init.action_headers))
+    const [monitorHeadersText, setMonitorHeadersText] = useState(headersToText(init.monitor_headers))
     const [errors, setErrors] = useState({})
 
     function set(field, value) {
@@ -110,6 +112,7 @@ function ServiceForm({ service, onSave, onCancel, saving, error }) {
             docker_container: form.docker_container.trim() || null,
             monitor_url: form.monitor_url.trim() || null,
             monitor_expect_body: form.monitor_expect_body.trim() || null,
+            monitor_headers: textToHeaders(monitorHeadersText) || null,
             action_headers: textToHeaders(headersText) || null,
             actions: form.actions.length ? form.actions.map(formToAction) : null,
         }
@@ -186,6 +189,14 @@ function ServiceForm({ service, onSave, onCancel, saving, error }) {
                                     <>
                                         <Field label="Monitor URL *">
                                             <input value={form.monitor_url} onChange={e => set("monitor_url", e.target.value)} placeholder="https://service.example.com/health" />
+                                        </Field>
+                                        <Field label="Monitor headers (one per line: Key: Value)">
+                                            <textarea
+                                                rows={2}
+                                                value={monitorHeadersText}
+                                                onChange={e => setMonitorHeadersText(e.target.value)}
+                                                placeholder="Authorization: Bearer eyJ..."
+                                            />
                                         </Field>
                                         <div className="form-row">
                                             <Field label="Interval (s)">


### PR DESCRIPTION
## Summary
Adds an optional `monitor-headers` field so services that require authentication (like Home Assistant) can be monitored via HTTP.

## Usage
In Config → Edit Home Assistant → Monitoring section → fill "Monitor headers":
```
Authorization: Bearer eyJ...your-long-lived-token
```

Config YAML equivalent:
```yaml
- name: Home Assistant
  monitor: true
  monitor-url: http://192.168.1.x:8123/api/
  monitor-headers:
    Authorization: Bearer eyJ...
  monitor-expect-status: 200
```

Home Assistant's `/api/` endpoint returns `{"message": "API running."}` with status 200 when the token is valid.

## Changes
- `yaml_models.py` — `monitor_headers: dict[str, str] | None`
- `monitoring.py` — headers passed to the `httpx` GET request
- `ServiceForm.jsx` — "Monitor headers" textarea in the Monitoring section (same format as Action headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)