### PR TITLE
fix: log HTTP monitor connection errors instead of failing silently

### DIFF
--- a/backend/monitoring.py
+++ b/backend/monitoring.py
@@ -29,7 +29,9 @@ async def _check_http(svc: YamlService) -> None:
                     _status_cache[svc.name] = "online" if ok else "offline"
                     logger.debug("Monitor %s -> %s", svc.name, _status_cache[svc.name])
                     return
-                except httpx.RequestError:
+                except httpx.RequestError as exc:
+                    logger.warning("Monitor request failed for '%s' (attempt %d/%d): %s",
+                                   svc.name, attempt + 1, svc.monitor_retries + 1, exc)
                     if attempt < svc.monitor_retries:
                         await asyncio.sleep(1)
             _status_cache[svc.name] = "offline"


### PR DESCRIPTION
`httpx.RequestError` was caught without logging, so DNS failures or
connection refused errors showed no trace in the logs — the service
just silently went Offline with no way to know why.

Now logs the service name, attempt number, and error message at WARNING
level so failures are visible in Grafana/Loki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)