### PR TITLE
feat: expose host machine to backend via host.docker.internal

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -24,6 +24,8 @@ services:
     volumes:
       - ./config:/app/config
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
     networks:
       - apollo-server-network


### PR DESCRIPTION
Adds `extra_hosts: host.docker.internal:host-gateway` to the backend service so it can reach processes running directly on the host (not in Docker), like Jenkins.

After merging and running `docker compose up -d`, configure Jenkins monitoring in the UI:
- **Monitor URL**: `http://host.docker.internal:<jenkins-port>/api/json`
- **Monitor headers**: `Authorization: Basic <base64(user:api-token)>`
- **Expect body contains**: `{"_class"` (or leave empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)