### PR TITLE
docs: rewrite README to reflect current architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,49 @@
 # Apollo Server Dashboard
 
-A home server dashboard inspired by Stream Deck. Each service is represented as a card with live status and contextual actions (restart, resend notifications, etc.).
+A home server dashboard inspired by Stream Deck. Each service is represented as a card with live status and contextual action buttons.
 
 Built with React + Vite (frontend) and FastAPI (backend). Runs as two Docker containers behind an nginx reverse proxy.
 
 ## Features
 
-- Live service status cards with auto-refresh every 30 seconds
-- Per-service action buttons (configurable per service)
+- Live service cards with auto-refresh every 30 seconds
+- Per-service action buttons (configurable: any HTTP method, custom body, confirm dialogs)
+- HTTP health monitoring with configurable intervals, retries, expected status and body
+- Docker container status monitoring via Docker socket
+- Custom monitor headers (for services that require authentication, e.g. Home Assistant)
+- Admin UI to manage services without editing files
+- Declarative YAML config — no code required to add services
 - API key authentication
-- Docker-ready with nginx reverse proxy
 
 ## Project Structure
 
 ```
 .
 ├── Dockerfile              # Frontend: Node.js builder → nginx
-├── nginx.conf              # nginx: serves SPA + proxies /services to backend
+├── nginx.conf              # nginx: serves SPA + proxies /services and /config to backend
 ├── compose.yaml            # Docker Compose orchestration
 ├── Jenkinsfile             # CI/CD pipeline (Jenkins shared library)
+├── config/
+│   └── services.yaml       # Service definitions (gitignored, created from example on first run)
 ├── src/                    # React frontend (Vite)
+│   └── components/
+│       ├── AdminPanel.jsx  # Config management UI
+│       ├── ServiceForm.jsx # Add / edit service form
+│       ├── ServiceCard.jsx # Dashboard card
+│       └── ActionPanel.jsx # Action button panel
 └── backend/
     ├── Dockerfile          # Python 3.12-slim + uvicorn
-    ├── main.py             # FastAPI app entry point
-    ├── models.py           # Pydantic models (Service, Action, ActionResult)
+    ├── main.py             # FastAPI app, auth, /services and /config endpoints
+    ├── models.py           # Pydantic models: Service, Action, ActionResult
+    ├── yaml_models.py      # Pydantic model for services.yaml
+    ├── config_loader.py    # Loads, validates, and saves services.yaml
+    ├── config_service.py   # Builds Service cards and dynamic action routes from YAML
+    ├── monitoring.py       # Background HTTP and Docker health check loop
+    ├── docker_client.py    # Docker socket wrapper: container status lookup
     ├── http_client.py      # Shared httpx client singleton
-    ├── upstream.py         # Shared helper: POST to upstream service + map errors to ActionResult
-    └── services/
-        ├── minecraft/      # Minecraft service card + actions
-        └── free_games_notifier/  # Free Games Notifier card + actions (resend, E2E checks)
+    ├── upstream.py         # Helper: call upstream service → ActionResult
+    ├── entrypoint.sh       # Grants Docker socket access to appuser at startup
+    └── services.example.yaml  # Annotated config reference
 ```
 
 ## Local Development
@@ -40,7 +55,7 @@ cd backend
 python3 -m venv env
 source env/bin/activate
 pip install -r requirements.txt
-uvicorn main:app --host 0.0.0.0 --port 8001 --reload
+API_KEY=dev uvicorn main:app --host 0.0.0.0 --port 8001 --reload
 ```
 
 ### Frontend
@@ -50,7 +65,7 @@ npm install
 npm run dev
 ```
 
-The Vite dev server proxies `/services` to `http://localhost:8001` automatically.
+The Vite dev server proxies `/services` and `/config` to `http://localhost:8001` automatically.
 
 ## Docker Deployment
 
@@ -67,49 +82,107 @@ The Vite dev server proxies `/services` to `http://localhost:8001` automatically
 
 ```bash
 cp .env.example .env
-# Edit .env as needed
-docker compose up -d
+# Edit .env — set API_KEY at minimum
+docker compose up -d --build
 ```
 
-The dashboard will be available at `http://<host>:3000`.
+On first run, `config/services.yaml` is created from the example template. Edit it or use the Admin UI (⚙ icon in the top right) to add your services.
+
+The dashboard will be available at `http://<host>:<FRONTEND_PORT>`.
 
 ## Environment Variables
 
 | Variable | Default | Description |
 |---|---|---|
-| `API_KEY` | _(required)_ | Secret key for the dashboard; must be set to a non-empty value |
-| `FRONTEND_PORT` | `3000` | Host port for the dashboard |
-| `FREE_GAMES_NOTIFIER_URL` | `http://free-games-notifier:8000` | URL of the Free Games Notifier service |
-| `FREE_GAMES_NOTIFIER_API_KEY` | _(empty)_ | API key for the Free Games Notifier service |
-| `FREE_GAMES_NOTIFIER_TEST_WEBHOOK_URL` | _(empty)_ | Discord webhook URL for test notifications |
+| `API_KEY` | _(required)_ | Secret key sent as `X-API-Key` on every request |
+| `FRONTEND_PORT` | `9902` | Host port for the dashboard |
+| `SERVICES_CONFIG` | `/app/config/services.yaml` | Path to the service config file inside the container |
 
-## Adding a New Service
+Additional variables (e.g. API keys, webhook URLs) can be defined in `.env` and referenced in `services.yaml` as `${MY_VAR}`.
 
-1. Create `backend/services/<service_name>/`
-2. Add `__init__.py` and `router.py` — implement `get_card() -> Service` and add `@router.post/get(...)` actions
-3. For action endpoints that POST to an upstream service, import and use the shared helper:
-   ```python
-   from upstream import post_to_upstream
+## Service Configuration
 
-   @router.post("/my-action")
-   def my_action() -> ActionResult:
-       return post_to_upstream(
-           f"{MY_SERVICE_URL}/some-endpoint",
-           headers={"X-API-Key": MY_SERVICE_API_KEY},
-       )
-   ```
-4. Import and register in `backend/main.py`
+Services are defined in `config/services.yaml`. You can edit the file directly or use the Admin UI. See `backend/services.example.yaml` for a full annotated reference.
+
+### Minimal example
+
+```yaml
+- name: Grafana
+  icon: bar-chart
+  url: https://grafana.example.com
+  monitor: true
+  monitor-url: https://grafana.example.com/api/health
+  monitor-expect-status: 200
+```
+
+### Docker health monitoring
+
+```yaml
+- name: Portainer
+  icon: container
+  url: https://portainer.example.com
+  docker-container: portainer
+  monitor: true
+  use-docker-health: true
+```
+
+### Authenticated health check (e.g. Home Assistant)
+
+```yaml
+- name: Home Assistant
+  icon: home
+  url: http://homeassistant.local:8123
+  monitor: true
+  monitor-url: http://192.168.1.50:8123/api/
+  monitor-headers:
+    Authorization: Bearer eyJ...
+  monitor-expect-status: 200
+```
+
+### Service with actions
+
+```yaml
+- name: My Service
+  icon: server
+  url: https://my-service.example.com
+  action-url: http://my-service:8000
+  action-timeout: 30
+  action-headers:
+    X-API-Key: ${MY_SERVICE_API_KEY}
+  actions:
+    - label: Restart
+      icon: rotate-cw
+      endpoint: /restart
+      method: POST
+      confirm: true
+    - label: Open UI
+      icon: external-link
+      endpoint: https://my-service.example.com
+      method: href
+```
+
+### Reaching non-Docker services on the same host
+
+Services not running in Docker (e.g. Jenkins) are reachable from the backend container via the host's LAN IP or by adding `extra_hosts` to `compose.yaml`:
+
+```yaml
+apollo-server-dashboard-backend:
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+```
+
+Then use `http://host.docker.internal:<port>` as the monitor or action URL.
 
 ## CI/CD (Jenkins)
 
-The included `Jenkinsfile` uses the shared pipeline library. Before first run:
+The included `Jenkinsfile` uses a shared pipeline library. Before first run:
 
 ```bash
 sudo mkdir /opt/stacks/apollo-server-dashboard
 sudo chown -R jenkins:jenkins /opt/stacks/apollo-server-dashboard
 ```
 
-Then create a Jenkins pipeline job pointing to this repository. The pipeline will build the Docker images, copy `compose.yaml` to the Dockge stack directory, and restart the stack.
+Create a Jenkins pipeline job pointing to this repository. The pipeline builds the Docker images, copies `compose.yaml` to the Dockge stack directory, and restarts the stack.
 
 > **Note:** Replace `'dockge-pipeline'` in `Jenkinsfile` with the actual name of your shared library as configured in Jenkins.
 


### PR DESCRIPTION
The README was describing the old hardcoded-Python-modules architecture. Updated to reflect the current state:

- Features: Admin UI, YAML config, HTTP/Docker monitoring, monitor headers
- Project structure: removed `backend/services/`, added all new backend modules
- Replaced "Adding a New Service" code instructions with YAML config examples
- Added examples for Docker health monitoring, authenticated health checks, non-Docker host services
- Corrected env vars (added `SERVICES_CONFIG`, removed stale ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)