### PR TITLE
feat: icon picker for service and action icons

### DIFF
--- a/src/components/ActionPanel.jsx
+++ b/src/components/ActionPanel.jsx
@@ -22,9 +22,11 @@ function ActionPanel ({service, onClose, apiKey}) {
 
     // Clear all pending timeouts on unmount
     useEffect(() => {
+        const errorTimeout = errorTimeoutRef
+        const stateTimeouts = stateTimeoutsRef
         return () => {
-            if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current);
-            Object.values(stateTimeoutsRef.current).forEach(clearTimeout);
+            if (errorTimeout.current) clearTimeout(errorTimeout.current);
+            Object.values(stateTimeouts.current).forEach(clearTimeout);
         };
     }, []);
 

--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { getIcon } from "../utils/icons"
 import ServiceForm from "./ServiceForm"
 import "./AdminPanel.css"
@@ -12,6 +12,14 @@ function AdminPanel({ onClose, apiKey, onConfigChanged }) {
     const [editingIndex, setEditingIndex] = useState(null) // null=list, "new"=add, number=edit
     const [deleteIndex, setDeleteIndex] = useState(null)
 
+    const handleCancelEdit = useCallback(() => {
+        if (window.history.state?.editingIndex !== undefined) {
+            history.back()
+        } else {
+            setEditingIndex(null)
+        }
+    }, [])
+
     useEffect(() => {
         const handleKey = (e) => {
             if (e.key === "Escape") {
@@ -21,7 +29,7 @@ function AdminPanel({ onClose, apiKey, onConfigChanged }) {
         }
         window.addEventListener("keydown", handleKey)
         return () => window.removeEventListener("keydown", handleKey)
-    }, [onClose, editingIndex])
+    }, [onClose, editingIndex, handleCancelEdit])
 
     // Sync editingIndex from browser history (back/forward navigation)
     useEffect(() => {
@@ -63,14 +71,6 @@ function AdminPanel({ onClose, apiKey, onConfigChanged }) {
         setEditingIndex(index)
         setFormError(null)
         history.pushState({ adminOpen: true, editingIndex: index }, "")
-    }
-
-    function handleCancelEdit() {
-        if (window.history.state?.editingIndex !== undefined) {
-            history.back()
-        } else {
-            setEditingIndex(null)
-        }
     }
 
     function handleSave(service) {

--- a/src/components/IconPicker.css
+++ b/src/components/IconPicker.css
@@ -1,0 +1,122 @@
+.icon-picker-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.75);
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    box-sizing: border-box;
+}
+
+.icon-picker {
+    background: var(--blueishDarkGray);
+    border: 0.5px solid #2a2d30;
+    border-radius: 10px;
+    width: 100%;
+    max-width: 660px;
+    max-height: 72vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.icon-picker-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px;
+    border-bottom: 0.5px solid #2a2d30;
+    flex-shrink: 0;
+}
+
+.icon-picker-search {
+    flex: 1;
+    background: var(--darkGray);
+    border: 0.5px solid #2a2d30;
+    border-radius: 6px;
+    color: var(--blueishWhite);
+    font-family: monospace;
+    font-size: 13px;
+    padding: 8px 12px;
+    outline: none;
+    transition: border-color 0.15s;
+    min-width: 0;
+}
+
+.icon-picker-search:focus {
+    border-color: var(--blue);
+}
+
+.icon-picker-close {
+    background: none;
+    border: none;
+    color: rgba(250, 250, 255, 0.3);
+    font-size: 14px;
+    cursor: pointer;
+    padding: 6px 8px;
+    transition: color 0.15s;
+    flex-shrink: 0;
+}
+
+.icon-picker-close:hover {
+    color: var(--blueishWhite);
+}
+
+.icon-picker-count {
+    font-family: monospace;
+    font-size: 10px;
+    color: rgba(250, 250, 255, 0.2);
+    padding: 5px 14px;
+    flex-shrink: 0;
+}
+
+.icon-picker-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(78px, 1fr));
+    gap: 2px;
+    overflow-y: auto;
+    padding: 6px 8px 12px;
+}
+
+.icon-picker-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    background: none;
+    border: 0.5px solid transparent;
+    border-radius: 6px;
+    color: rgba(250, 250, 255, 0.45);
+    cursor: pointer;
+    padding: 10px 6px 8px;
+    font-family: monospace;
+    font-size: 9px;
+    word-break: break-all;
+    text-align: center;
+    line-height: 1.3;
+    transition: background 0.1s, border-color 0.1s, color 0.1s;
+}
+
+.icon-picker-item:hover {
+    background: rgba(255, 255, 255, 0.05);
+    border-color: #2a2d30;
+    color: var(--blueishWhite);
+}
+
+.icon-picker-item.selected {
+    background: rgba(64, 156, 255, 0.1);
+    border-color: var(--blue);
+    color: var(--blue);
+}
+
+.icon-picker-empty {
+    font-family: monospace;
+    font-size: 12px;
+    color: rgba(250, 250, 255, 0.3);
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 40px 16px;
+    margin: 0;
+}

--- a/src/components/IconPicker.jsx
+++ b/src/components/IconPicker.jsx
@@ -1,0 +1,88 @@
+import { useState, useMemo, useEffect, useRef } from "react"
+import * as LucideIcons from "lucide-react"
+import "./IconPicker.css"
+
+function toKebabCase(pascal) {
+    return pascal.replace(/([A-Z])/g, (_, l, i) => i === 0 ? l.toLowerCase() : `-${l.toLowerCase()}`)
+}
+
+const SHOW_ALL_THRESHOLD = 300
+
+// Each icon comes as two exports: Foo and FooIcon. Keep only the base name.
+// LucideProvider is the only non-icon uppercase export — exclude it.
+const ALL_ICONS = Object.keys(LucideIcons)
+    .filter(name => /^[A-Z]/.test(name) && !name.endsWith("Icon") && name !== "LucideProvider")
+    .map(pascal => ({ pascal, kebab: toKebabCase(pascal) }))
+    .sort((a, b) => a.kebab.localeCompare(b.kebab))
+
+function IconPicker({ value, onChange, onClose }) {
+    const [search, setSearch] = useState("")
+    const searchRef = useRef(null)
+
+    useEffect(() => {
+        searchRef.current?.focus()
+    }, [])
+
+    useEffect(() => {
+        const handleKey = (e) => {
+            if (e.key === "Escape") onClose()
+        }
+        window.addEventListener("keydown", handleKey)
+        return () => window.removeEventListener("keydown", handleKey)
+    }, [onClose])
+
+    const filtered = useMemo(() => {
+        const q = search.toLowerCase().trim()
+        if (!q) return ALL_ICONS.slice(0, SHOW_ALL_THRESHOLD)
+        return ALL_ICONS.filter(({ kebab }) => kebab.includes(q))
+    }, [search])
+
+    function handleSelect(kebab) {
+        onChange(kebab)
+        onClose()
+    }
+
+    return (
+        <div className="icon-picker-backdrop" onClick={onClose}>
+            <div className="icon-picker" onClick={e => e.stopPropagation()}>
+                <div className="icon-picker-header">
+                    <input
+                        ref={searchRef}
+                        className="icon-picker-search"
+                        placeholder="Search icons…"
+                        value={search}
+                        onChange={e => setSearch(e.target.value)}
+                    />
+                    <button type="button" className="icon-picker-close" onClick={onClose}>✕</button>
+                </div>
+                <div className="icon-picker-count">
+                    {search.trim()
+                        ? `${filtered.length} result${filtered.length !== 1 ? "s" : ""}`
+                        : `Showing ${SHOW_ALL_THRESHOLD} of ${ALL_ICONS.length} — search to filter`}
+                </div>
+                <div className="icon-picker-grid">
+                    {filtered.map(({ pascal, kebab }) => {
+                        const Icon = LucideIcons[pascal]
+                        return (
+                            <button
+                                key={pascal}
+                                type="button"
+                                className={`icon-picker-item${value === kebab ? " selected" : ""}`}
+                                onClick={() => handleSelect(kebab)}
+                                title={kebab}
+                            >
+                                <Icon size={18} />
+                                <span>{kebab}</span>
+                            </button>
+                        )
+                    })}
+                    {filtered.length === 0 && (
+                        <p className="icon-picker-empty">No icons match "{search}"</p>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default IconPicker

--- a/src/components/ServiceForm.css
+++ b/src/components/ServiceForm.css
@@ -149,10 +149,31 @@
     background: transparent;
     flex: 1;
     padding: 8px 10px 8px 0;
+    min-width: 0;
 }
 
 .icon-input input:focus {
     border: none;
+}
+
+.icon-browse-btn {
+    background: none;
+    border: none;
+    border-left: 0.5px solid #2a2d30;
+    color: rgba(250, 250, 255, 0.25);
+    cursor: pointer;
+    padding: 0 10px;
+    display: flex;
+    align-items: center;
+    align-self: stretch;
+    transition: color 0.15s, background 0.15s;
+    border-radius: 0 6px 6px 0;
+    flex-shrink: 0;
+}
+
+.icon-browse-btn:hover {
+    color: var(--blue);
+    background: rgba(64, 156, 255, 0.08);
 }
 
 .toggle-label {

--- a/src/components/ServiceForm.jsx
+++ b/src/components/ServiceForm.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import { getIcon } from "../utils/icons"
+import IconPicker from "./IconPicker"
 import "./ServiceForm.css"
 
 const METHODS = ["href", "GET", "POST", "PUT", "DELETE", "PATCH"]
@@ -64,6 +65,8 @@ function ServiceForm({ service, onSave, onCancel, saving, error }) {
     const [headersText, setHeadersText] = useState(headersToText(init.action_headers))
     const [monitorHeadersText, setMonitorHeadersText] = useState(headersToText(init.monitor_headers))
     const [errors, setErrors] = useState({})
+    // pickerFor: null=closed | "service-icon" | { actionIndex: number }
+    const [pickerFor, setPickerFor] = useState(null)
 
     function set(field, value) {
         setForm(f => ({ ...f, [field]: value }))
@@ -139,6 +142,9 @@ function ServiceForm({ service, onSave, onCancel, saving, error }) {
                                 <div className="icon-input">
                                     <span className="icon-preview">{getIcon(form.icon, { size: 14 })}</span>
                                     <input value={form.icon} onChange={e => set("icon", e.target.value)} placeholder="server" />
+                                    <button type="button" className="icon-browse-btn" onClick={() => setPickerFor("service-icon")} title="Browse icons">
+                                        {getIcon("layout-grid", { size: 12 })}
+                                    </button>
                                 </div>
                             </Field>
                         </div>
@@ -240,6 +246,9 @@ function ServiceForm({ service, onSave, onCancel, saving, error }) {
                                         <div className="icon-input">
                                             <span className="icon-preview">{getIcon(action.icon, { size: 14 })}</span>
                                             <input value={action.icon} onChange={e => setAction(i, "icon", e.target.value)} placeholder="play" />
+                                            <button type="button" className="icon-browse-btn" onClick={() => setPickerFor({ actionIndex: i })} title="Browse icons">
+                                                {getIcon("layout-grid", { size: 12 })}
+                                            </button>
                                         </div>
                                     </Field>
                                 </div>
@@ -280,6 +289,17 @@ function ServiceForm({ service, onSave, onCancel, saving, error }) {
                     </button>
                 </div>
             </form>
+
+            {pickerFor !== null && (
+                <IconPicker
+                    value={pickerFor === "service-icon" ? form.icon : form.actions[pickerFor.actionIndex]?.icon ?? ""}
+                    onChange={kebab => {
+                        if (pickerFor === "service-icon") set("icon", kebab)
+                        else setAction(pickerFor.actionIndex, "icon", kebab)
+                    }}
+                    onClose={() => setPickerFor(null)}
+                />
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Summary

- Adds a **visual icon browser** to the Icon field in the service form (both the service icon and each action's icon)
- Clicking the grid button (⊞) next to any icon input opens a searchable picker
- Shows 300 icons alphabetically on open; typing filters from all ~3 875 available Lucide icons in real time
- Currently selected icon is highlighted in blue
- Closes on selection, Escape, or clicking the backdrop
- Fixes two pre-existing ESLint errors in `AdminPanel.jsx` and `ActionPanel.jsx`

## Test plan

- [ ] Open Admin → Edit any service → click the ⊞ button next to the Icon field
- [ ] Verify the picker opens with an auto-focused search box
- [ ] Type part of an icon name (e.g. "server") and confirm results filter correctly
- [ ] Click an icon and confirm the field updates and the picker closes
- [ ] Verify the icon preview in the input updates immediately
- [ ] Open picker for an action icon (Add action → click ⊞) — same behaviour
- [ ] Press Escape to close without selecting — field unchanged
- [ ] Click the backdrop to close — field unchanged
- [ ] Run `npm run lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)