### PR TITLE
feat: hot-reload action routes without backend restart

### DIFF
--- a/backend/config_service.py
+++ b/backend/config_service.py
@@ -1,11 +1,13 @@
 import logging
 import re
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from models import Action, ActionResult, Service
 from monitoring import get_status
 from upstream import call_upstream
 from yaml_models import YamlService
+
+import config_loader
 
 logger = logging.getLogger(__name__)
 
@@ -39,31 +41,50 @@ def yaml_to_card(svc: YamlService) -> Service:
     )
 
 
-def _make_handler(url: str, method: str, label: str, headers: dict | None, body: dict | None, timeout: float):
-    def handler() -> ActionResult:
-        return call_upstream(url, method=method, label=label, headers=headers, body=body, timeout=timeout)
-    return handler
+def action_dispatcher(service_slug: str, action_slug: str) -> ActionResult:
+    """Single handler for all action routes — reads live config on every call.
+
+    This means adding, editing, or removing services with actions from the
+    Admin UI takes effect immediately without a backend restart.
+    """
+    services = config_loader.get_services()
+
+    svc = next((s for s in services if _slug(s.name) == service_slug), None)
+    if svc is None:
+        raise HTTPException(status_code=404, detail=f"Service '{service_slug}' not found")
+
+    action = next(
+        (a for a in (svc.actions or []) if _slug(a.label) == action_slug),
+        None,
+    )
+    if action is None:
+        raise HTTPException(status_code=404, detail=f"Action '{action_slug}' not found on service '{service_slug}'")
+
+    if action.method.lower() == "href":
+        raise HTTPException(status_code=400, detail="href actions are client-side navigation, not callable endpoints")
+
+    if not svc.action_url:
+        raise HTTPException(status_code=500, detail=f"Service '{svc.name}' has no action-url configured")
+
+    upstream_url = svc.action_url.rstrip("/") + action.endpoint
+    headers = dict(svc.action_headers) if svc.action_headers else None
+
+    logger.info("Dispatch %s /services/%s/actions/%s -> %s", action.method.upper(), service_slug, action_slug, upstream_url)
+    return call_upstream(upstream_url, method=action.method, label=action.label, headers=headers, body=action.body, timeout=svc.action_timeout)
 
 
-def build_config_router(services: list[YamlService]) -> APIRouter:
+def build_config_router() -> APIRouter:
+    """Return a router with a single catch-all dispatcher for all action endpoints.
+
+    Routes are no longer baked at startup — the dispatcher reads live config on
+    every request, so config changes from the Admin UI take effect immediately.
+    """
     router = APIRouter()
-    for svc in services:
-        if not svc.actions:
-            continue
-        slug = _slug(svc.name)
-        for action in svc.actions:
-            if action.method.lower() == "href":
-                continue
-            if not svc.action_url:
-                logger.warning(
-                    "Service '%s' action '%s' has method '%s' but no action-url — skipping",
-                    svc.name, action.label, action.method,
-                )
-                continue
-            upstream_url = svc.action_url.rstrip("/") + action.endpoint
-            path = f"/services/{slug}/actions/{_slug(action.label)}"
-            headers = dict(svc.action_headers) if svc.action_headers else None
-            handler = _make_handler(upstream_url, action.method, action.label, headers, action.body, svc.action_timeout)
-            router.add_api_route(path, handler, methods=[action.method.upper()], response_model=ActionResult)
-            logger.info("Registered %s %s -> %s (timeout=%ss)", action.method.upper(), path, upstream_url, svc.action_timeout)
+    router.add_api_route(
+        "/services/{service_slug}/actions/{action_slug}",
+        action_dispatcher,
+        methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
+        response_model=ActionResult,
+    )
+    logger.info("Registered live-config action dispatcher at /services/{service_slug}/actions/{action_slug}")
     return router

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,8 +42,7 @@ def verify_api_key(api_key: str = Security(api_key_header)):
 async def lifespan(app: FastAPI):
     config_loader.load_config()
     http_client.init()
-    services = config_loader.get_services()
-    app.include_router(build_config_router(services))
+    app.include_router(build_config_router())
     monitor_task = asyncio.create_task(run_monitoring_loop())
     yield
     monitor_task.cancel()


### PR DESCRIPTION
Closes #65

## What changed

Replaced the startup-time route registration with a single live-config dispatcher.

**Before:** `build_config_router(services)` iterated over the service list at startup and registered one FastAPI route per action (e.g. `POST /services/my-service/actions/restart`). Adding a new service with actions required a backend restart for the routes to appear.

**After:** A single route `/services/{service_slug}/actions/{action_slug}` handles all action calls. On every request the dispatcher calls `config_loader.get_services()` (the same in-memory cache the monitoring loop uses) to resolve the service and action, then proxies to the upstream. Config changes from the Admin UI are immediately effective.

## Changes

- `backend/config_service.py` — replaced `build_config_router(services)` + `_make_handler` with `action_dispatcher` + `build_config_router()` (no args)
- `backend/main.py` — simplified lifespan: no longer loads services before building the router; removed unused `YamlService` import (then restored — still needed for `/config` endpoints)

## Error handling

| Scenario | Response |
|---|---|
| Service slug not in config | `404 Service '…' not found` |
| Action slug not on service | `404 Action '…' not found on service '…'` |
| Action is `href` type | `400` (client-side only) |
| Service has no `action-url` | `500` (misconfiguration) |
| Upstream error | existing `ActionResult(success=False, message=…)` behaviour |

## Test plan

- [ ] Existing services with actions still work (trigger an action, confirm it reaches the upstream)
- [ ] Add a new service with actions via Admin UI — action buttons work immediately, no restart needed
- [ ] Edit an action's endpoint/method via Admin UI — new config takes effect on next click
- [ ] Delete a service — its action endpoint returns 404
- [ ] Backend logs show `Dispatch POST /services/…/actions/…` on each action call

🤖 Generated with [Claude Code](https://claude.com/claude-code)