### PR TITLE
feat: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: React / Vite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+        continue-on-error: false
+
+      - name: Lint frontend
+        run: npm run lint
+        continue-on-error: false
+
+      - name: Build frontend
+        run: npm run build
+        continue-on-error: false
+
+  backend:
+    name: FastAPI backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt ruff
+        continue-on-error: false
+
+      - name: Lint backend
+        run: ruff check backend
+        continue-on-error: false
+
+      - name: Check backend modules compile
+        run: python -m compileall -q backend
+        continue-on-error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: ["**"]
   pull_request:
     branches: [main]
 
@@ -24,15 +25,12 @@ jobs:
 
       - name: Install frontend dependencies
         run: npm ci
-        continue-on-error: false
 
       - name: Lint frontend
         run: npm run lint
-        continue-on-error: false
 
       - name: Build frontend
         run: npm run build
-        continue-on-error: false
 
   backend:
     name: FastAPI backend
@@ -52,12 +50,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt ruff
-        continue-on-error: false
 
       - name: Lint backend
         run: ruff check backend
-        continue-on-error: false
 
       - name: Check backend modules compile
         run: python -m compileall -q backend
-        continue-on-error: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Apollo Server Dashboard
 
+[![CI](https://github.com/JulioMoralesB/apollo-server-dashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/JulioMoralesB/apollo-server-dashboard/actions/workflows/ci.yml)
+
 A home server dashboard inspired by Stream Deck. Each service is represented as a card with live status and contextual action buttons.
 
 Built with React + Vite (frontend) and FastAPI (backend). Runs as two Docker containers behind an nginx reverse proxy.


### PR DESCRIPTION
## What changed
- Add `.github/workflows/ci.yml` with parallel React/Vite and FastAPI backend jobs.
- Frontend job uses `npm ci`, `npm run lint`, and `npm run build` on Ubuntu.
- Backend job installs `backend/requirements.txt` plus `ruff`, then uses `ruff check backend` and `python -m compileall -q backend`.
- Add the CI status badge to the README.

## How to test
- `git diff --check`
- Static workflow/readme assertions for the requested commands and badge
- `python3 -m compileall -q backend`

Note: I could not execute the frontend npm checks locally because this runner does not have `npm`; the GitHub Actions job is set up to execute those checks in a clean Node 20 environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated continuous integration pipeline that verifies code quality and builds on every commit and pull request for both frontend and backend components.
  * Added workflow status badge to project README for build visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->