### PR TITLE
feat: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - run: pip install -r backend/requirements.txt ruff
+
+      - run: ruff check backend
+
+      - run: python -m compileall -q backend

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Apollo Server Dashboard
 
+[![CI](https://github.com/JulioMoralesB/apollo-server-dashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/JulioMoralesB/apollo-server-dashboard/actions/workflows/ci.yml)
+
 A home server dashboard inspired by Stream Deck. Each service is represented as a card with live status and contextual action buttons.
 
 Built with React + Vite (frontend) and FastAPI (backend). Runs as two Docker containers behind an nginx reverse proxy.


### PR DESCRIPTION
## What changed
- Add `.github/workflows/ci.yml` with two parallel jobs: `frontend` and `backend`
- **Frontend job** (ubuntu-latest): `npm ci` → `npm run lint` → `npm run build`; npm cache enabled
- **Backend job** (ubuntu-latest): installs `requirements.txt` + `ruff` → `ruff check backend` → `python -m compileall -q backend`; pip cache enabled
- Add CI status badge to README

## How to test
- Push any branch or open a PR targeting `main` — both jobs should appear in the Actions tab
- A lint error or build failure in either job will block the PR

Closes #78