### PR TITLE
feat: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/juliomoralesb/apollo-server-dashboard
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  backend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/juliomoralesb/apollo-server-dashboard-backend
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What changed
- Add `.github/workflows/release.yml` with two parallel jobs that run on every `v*.*.*` tag push
- **`frontend` job** — builds and pushes the root `Dockerfile` (nginx + React SPA) to `ghcr.io/juliomoralesb/apollo-server-dashboard`
- **`backend` job** — builds and pushes `backend/Dockerfile` (FastAPI) to `ghcr.io/juliomoralesb/apollo-server-dashboard-backend`
- Both images are tagged with the semver version (e.g. `1.2.3`) and `latest`
- Both images are built for `linux/amd64` and `linux/arm64` (homelab ARM support)
- Uses `GITHUB_TOKEN` — no extra secrets required

## How to test
```bash
git tag v0.1.0 && git push origin v0.1.0
```
Both images should appear in the repo's **Packages** tab after the workflow completes and be publicly pullable:
```bash
docker pull ghcr.io/juliomoralesb/apollo-server-dashboard:latest
docker pull ghcr.io/juliomoralesb/apollo-server-dashboard-backend:latest
```

Closes #79