### PR TITLE
feat: add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, homelab]
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    env:
+      REPO: ${{ github.repository }}
+      VERSION: ${{ github.event.workflow_run.head_branch }}
+    steps:
+      - name: Trigger Portainer redeploy
+        run: curl -fsS -X POST "${{ secrets.PORTAINER_WEBHOOK_URL }}"
+
+      - name: Notify deployment success
+        run: |
+          curl -fsS -X POST "${{ secrets.N8N_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"repo\":\"$REPO\",\"version\":\"$VERSION\",\"status\":\"deployed\"}"
+
+      - name: Notify deployment failure
+        if: failure()
+        run: |
+          curl -fsS -X POST "${{ secrets.N8N_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"repo\":\"$REPO\",\"version\":\"$VERSION\",\"status\":\"failed\"}"


### PR DESCRIPTION
## What changed
- Add `.github/workflows/deploy.yml` that runs on the self-hosted homelab runner
- Triggers automatically when the `Release` workflow completes successfully (`workflow_run` event)
- **Steps:**
  1. `curl -X POST $PORTAINER_WEBHOOK_URL` — triggers Portainer stack redeploy
  2. `curl -X POST $N8N_WEBHOOK_URL` with `{"repo","version","status":"deployed"}` — triggers n8n → Telegram
- On failure: sends `{"status":"failed"}` to the same n8n webhook

## Required secrets
Before this workflow can run, add these secrets in **Settings → Secrets and variables → Actions**:
- `PORTAINER_WEBHOOK_URL` — the Portainer stack webhook URL (local network access via self-hosted runner)
- `N8N_WEBHOOK_URL` — the n8n webhook URL (integration already running)

## How to test
Push a semver tag → `release.yml` completes → this workflow fires → Portainer redeploys → Telegram notification received.

Closes #80